### PR TITLE
fix(ui): timeline content slot and dot z-index

### DIFF
--- a/.changeset/timeline-enhancements.md
+++ b/.changeset/timeline-enhancements.md
@@ -1,0 +1,5 @@
+---
+"@uiid/indicators": patch
+---
+
+Add content slot to timeline items and reduce dot z-index. TimelineContentProps now extends StackProps for layout prop support.

--- a/packages/indicators/src/timeline/timeline.module.css
+++ b/packages/indicators/src/timeline/timeline.module.css
@@ -11,7 +11,7 @@
 /* Timeline Dot */
 .timeline-dot {
   position: relative;
-  z-index: 10;
+  z-index: 1;
   display: flex;
   width: var(--timeline-dot-size);
   height: var(--timeline-dot-size);

--- a/packages/indicators/src/timeline/timeline.tsx
+++ b/packages/indicators/src/timeline/timeline.tsx
@@ -111,32 +111,44 @@ export function Timeline({
     <StoreContext.Provider value={store}>
       <TimelineContext.Provider value={contextValue}>
         <SwitchRender
-          condition={orientation === "vertical"}
-          render={{ true: <Stack gap={2} />, false: <Group gap={2} /> }}
-          role="list"
-          aria-orientation={orientation}
           data-slot="timeline"
+          role="list"
+          className={cx(
+            styles["timeline"],
+            timelineVariants({ color }),
+            className,
+          )}
+          render={{ true: <Stack gap={2} />, false: <Group gap={2} /> }}
+          condition={orientation === "vertical"}
+          aria-orientation={orientation}
           data-orientation={orientation}
           dir={dir}
-          className={cx(styles["timeline"], timelineVariants({ color }), className)}
           {...props}
         >
           {items
-            ? items.map(({ title, description, time, color: itemColor }, i) => (
-                <TimelineItem key={i} color={itemColor} {...ItemProps}>
-                  <TimelineDot {...DotProps} />
-                  <TimelineConnector {...ConnectorProps} />
-                  <TimelineContent {...ContentProps}>
-                    <TimelineTitle {...TitleProps}>{title}</TimelineTitle>
-                    {time && <TimelineTime {...TimeProps}>{time}</TimelineTime>}
-                    {description && (
-                      <TimelineDescription {...DescriptionProps}>
-                        {description}
-                      </TimelineDescription>
-                    )}
-                  </TimelineContent>
-                </TimelineItem>
-              ))
+            ? items.map(
+                (
+                  { title, description, time, color: itemColor, content },
+                  i,
+                ) => (
+                  <TimelineItem key={i} color={itemColor} {...ItemProps}>
+                    <TimelineDot {...DotProps} />
+                    <TimelineConnector {...ConnectorProps} />
+                    <TimelineContent {...ContentProps}>
+                      <TimelineTitle {...TitleProps}>{title}</TimelineTitle>
+                      {time && (
+                        <TimelineTime {...TimeProps}>{time}</TimelineTime>
+                      )}
+                      {description && (
+                        <TimelineDescription {...DescriptionProps}>
+                          {description}
+                        </TimelineDescription>
+                      )}
+                      {content}
+                    </TimelineContent>
+                  </TimelineItem>
+                ),
+              )
             : children}
         </SwitchRender>
       </TimelineContext.Provider>

--- a/packages/indicators/src/timeline/timeline.types.ts
+++ b/packages/indicators/src/timeline/timeline.types.ts
@@ -1,3 +1,4 @@
+import type { StackProps } from "@uiid/layout";
 import type { TextProps } from "@uiid/typography";
 import type { VariantProps } from "@uiid/utils";
 
@@ -45,6 +46,7 @@ export type TimelineItemType = {
   description?: string;
   time?: string;
   color?: VariantProps<typeof timelineVariants>["color"];
+  content?: React.ReactNode;
 };
 
 export type TimelineItemProps = React.ComponentProps<"div"> &
@@ -54,7 +56,7 @@ export type TimelineConnectorProps = React.ComponentProps<"div"> & {
   /** Force mount even if last item */
   forceMount?: boolean;
 };
-export type TimelineContentProps = React.ComponentProps<"div">;
+export type TimelineContentProps = StackProps;
 export type TimelineHeaderProps = React.ComponentProps<"div">;
 export type TimelineTitleProps = TextProps;
 export type TimelineDescriptionProps = TextProps;


### PR DESCRIPTION
## Summary
- Add `content` prop to `TimelineItemType` for rendering arbitrary content in timeline items
- Reduce timeline dot `z-index` from 10 to 1 (was unnecessarily high)
- Change `TimelineContentProps` from `ComponentProps<"div">` to `StackProps` for layout prop support

## Test plan
- [x] Timeline renders custom content via `content` prop
- [x] Timeline dot displays correctly with reduced z-index
- [x] Per-item colors render correctly in Storybook