### PR TITLE
feat(ui): allow controlled open state on ListItemGroup

### DIFF
--- a/.changeset/list-item-group-controlled-open.md
+++ b/.changeset/list-item-group-controlled-open.md
@@ -1,0 +1,5 @@
+---
+"@uiid/lists": patch
+---
+
+Expose `open`, `defaultOpen`, and `onOpenChange` on `ListItemGroup` so consumers can control collapsible state.

--- a/apps/storybook/stories/lists/list.stories.tsx
+++ b/apps/storybook/stories/lists/list.stories.tsx
@@ -1,6 +1,7 @@
+import { useMemo, useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
-import { Group, Stack, List } from "@uiid/design-system";
+import { Button, Group, Stack, List, type ListItemOrGroup } from "@uiid/design-system";
 import { MOCK_ITEMS, MOCK_LINKS, MOCK_NESTED } from "./list.mocks";
 
 const meta = {
@@ -39,6 +40,53 @@ export const NestedGroups: Story = {
   name: "Nested Groups",
   args: { items: MOCK_NESTED },
   render: (args) => <List {...args} line />,
+};
+
+export const ControlledOpen: Story = {
+  name: "Controlled Open",
+  render: () => {
+    const items: ListItemOrGroup[] = MOCK_LINKS ?? [];
+    const groupKeys = useMemo(
+      () =>
+        items
+          .filter((item): item is Extract<ListItemOrGroup, { items: unknown }> =>
+            "items" in item,
+          )
+          .map((group) => group.id ?? group.category ?? ""),
+      [items],
+    );
+
+    const [openMap, setOpenMap] = useState<Record<string, boolean>>(() =>
+      Object.fromEntries(groupKeys.map((key) => [key, true])),
+    );
+
+    const allOpen = groupKeys.every((key) => openMap[key]);
+
+    const toggleAll = () =>
+      setOpenMap(Object.fromEntries(groupKeys.map((key) => [key, !allOpen])));
+
+    const decorated = items.map((item) => {
+      if (!("items" in item)) return item;
+      const key = item.id ?? item.category ?? "";
+      return {
+        ...item,
+        open: openMap[key],
+        onOpenChange: (open: boolean) =>
+          setOpenMap((map) => ({ ...map, [key]: open })),
+      };
+    });
+
+    return (
+      <Stack gap={4}>
+        <Group ax="end">
+          <Button size="small" onClick={toggleAll}>
+            {allOpen ? "Collapse all" : "Expand all"}
+          </Button>
+        </Group>
+        <List items={decorated} line size="small" />
+      </Stack>
+    );
+  },
 };
 
 export const Sizes: Story = {

--- a/packages/lists/src/list/list.types.ts
+++ b/packages/lists/src/list/list.types.ts
@@ -1,3 +1,5 @@
+import type { Collapsible } from "@base-ui/react";
+
 import type { Icon } from "@uiid/icons";
 import type { BoxProps, GroupProps, StackProps } from "@uiid/layout";
 
@@ -25,7 +27,7 @@ export type ListItemGroupProps = {
   collapsible?: boolean;
   icon?: Icon;
   items: ListItemOrGroup[];
-};
+} & Pick<Collapsible.Root.Props, "open" | "defaultOpen" | "onOpenChange">;
 
 type BaseListProps = Omit<BoxProps, "ax" | "ay" | "direction"> & {
   type?: "ordered" | "unordered" | "none";

--- a/packages/lists/src/list/subcomponents/list-item-group.tsx
+++ b/packages/lists/src/list/subcomponents/list-item-group.tsx
@@ -15,6 +15,9 @@ import styles from "../list.module.css";
 export const ListItemGroup = ({
   category,
   collapsible,
+  open,
+  defaultOpen = true,
+  onOpenChange,
   icon: Icon,
   items,
 }: ListItemGroupProps) => {
@@ -25,7 +28,16 @@ export const ListItemGroup = ({
       fullwidth
       className={styles["list-item-group"]}
       render={
-        collapsible ? <Collapsible.Root render={<li />} defaultOpen /> : <li />
+        collapsible ? (
+          <Collapsible.Root
+            render={<li />}
+            open={open}
+            defaultOpen={defaultOpen}
+            onOpenChange={onOpenChange}
+          />
+        ) : (
+          <li />
+        )
       }
     >
       {category && (


### PR DESCRIPTION
## Summary
- Extend `ListItemGroupProps` with `open`, `defaultOpen`, and `onOpenChange` (picked from `Collapsible.Root.Props`) so consumers can drive collapsible state from the outside.
- Pass the new props through `Collapsible.Root` in `list-item-group.tsx`. `defaultOpen` defaults to `true`, preserving existing uncontrolled behavior.
- Add a `Controlled Open` Storybook story demonstrating an "Expand all / Collapse all" toggle on `MOCK_LINKS`.

## Breaking Changes
None — `defaultOpen` defaulting to `true` preserves the previous hardcoded behavior; existing consumers are unaffected.

## Motivation
Needed in a downstream consumer to add an "expand/collapse all" control over a multi-group sidebar. Without external open state, that interaction has no clean point of entry.

## Checklist
- [x] `ListItemGroupProps` exposes `open`, `defaultOpen`, `onOpenChange` via `Pick<Collapsible.Root.Props, ...>` (no duplicated lib types).
- [x] `defaultOpen` continues to default to `true` so existing uncontrolled usage is unchanged.
- [x] New props are forwarded to `Collapsible.Root` only when `collapsible` is true.
- [x] `.changeset/list-item-group-controlled-open.md` adds a `patch` bump for `@uiid/lists` (pre-1.0 rule).
- [x] `Controlled Open` story renders, the toggle button flips all groups, and individual group toggles still work.