### PR TITLE
refactor: introduce CSS Modules composes via @uiid/tokens/compositions.module.css

### DIFF
--- a/.changeset/compositions-disabled.md
+++ b/.changeset/compositions-disabled.md
@@ -1,0 +1,10 @@
+---
+"@uiid/tokens": patch
+"@uiid/buttons": patch
+"@uiid/code": patch
+"@uiid/forms": patch
+"@uiid/interactive": patch
+"@uiid/navigation": patch
+---
+
+Introduce `@uiid/tokens/compositions.module.css` as a shared CSS Modules source for `composes`. Adds a `.disabled` class that bundles `opacity: var(--globals-disabled-opacity)` and `pointer-events: none` under the new `uiid.compositions` layer, and converts 14 consumers (input, checkbox, radio, switch, textarea, slider, number-field's increment/decrement, button, code-editor, sidebar-menu-button, sidebar-menu-sub-button, accordion-root, resizable-handle, sortable-item-handle) to compose this source instead of duplicating the rule.

--- a/packages/buttons/src/button/button.module.css
+++ b/packages/buttons/src/button/button.module.css
@@ -1,6 +1,8 @@
 @import "@uiid/tokens/component/button.tokens.css";
 
 .button {
+  composes: disabled from "@uiid/tokens/compositions.module.css";
+
   --button-bg: var(--shade-foreground);
   --button-fg: var(--shade-background);
 
@@ -31,11 +33,6 @@
   &:focus-visible {
     outline: var(--globals-outline-style) var(--globals-outline-width) var(--globals-outline-color);
     outline-offset: var(--globals-outline-offset);
-  }
-
-  &:where([aria-disabled="true"], [disabled]) {
-    opacity: var(--globals-disabled-opacity);
-    pointer-events: none;
   }
 
   svg {

--- a/packages/code/src/code-editor/code-editor.module.css
+++ b/packages/code/src/code-editor/code-editor.module.css
@@ -1,13 +1,10 @@
 .code-editor {
+  composes: disabled from "@uiid/tokens/compositions.module.css";
+
   border: var(--globals-border-width) solid var(--globals-border-color);
   border-radius: var(--globals-border-radius);
   overflow: hidden;
   position: relative;
-}
-
-.code-editor[data-disabled] {
-  opacity: var(--globals-disabled-opacity);
-  pointer-events: none;
 }
 
 /* Highlighted code backdrop */

--- a/packages/forms/src/checkbox/checkbox.module.css
+++ b/packages/forms/src/checkbox/checkbox.module.css
@@ -1,6 +1,8 @@
 @import "@uiid/tokens/component/checkbox.tokens.css";
 
 .checkbox {
+  composes: disabled from "@uiid/tokens/compositions.module.css";
+
   /** todo: replace with default */
   width: var(--checkbox-size-sm);
   aspect-ratio: 1;
@@ -30,11 +32,6 @@
   &:focus-visible {
     outline: var(--globals-outline-style) var(--globals-outline-width) var(--globals-outline-color);
     outline-offset: var(--globals-outline-offset);
-  }
-
-  &:where(:disabled, [disabled], [data-disabled]) {
-    opacity: var(--globals-disabled-opacity);
-    pointer-events: none;
   }
 
   &[data-invalid] {

--- a/packages/forms/src/input/input.module.css
+++ b/packages/forms/src/input/input.module.css
@@ -1,5 +1,9 @@
 @import "@uiid/tokens/semantic/forms.tokens.css";
 
+.input {
+  composes: disabled from "@uiid/tokens/compositions.module.css";
+}
+
 .input:where(:not([data-slot="select-value"])) {
   background-color: var(--forms-bg);
   border-width: var(--globals-border-width);
@@ -23,12 +27,6 @@
   &:focus {
     background-color: var(--forms-bg-focus);
     outline-style: var(--globals-outline-style);
-  }
-
-  /** Disabled */
-  &:where(:disabled, [disabled], [data-disabled]) {
-    pointer-events: none;
-    opacity: var(--globals-disabled-opacity);
   }
 
   /** Invalid */

--- a/packages/forms/src/number-field/number-field.module.css
+++ b/packages/forms/src/number-field/number-field.module.css
@@ -28,6 +28,13 @@
   }
 }
 
+.number-field-decrement {
+  composes: disabled from "@uiid/tokens/compositions.module.css";
+}
+.number-field-increment {
+  composes: disabled from "@uiid/tokens/compositions.module.css";
+}
+
 .number-field-decrement,
 .number-field-increment {
   box-sizing: border-box;
@@ -56,11 +63,6 @@
 
   &:active {
     background-color: var(--forms-bgActive);
-  }
-
-  &:disabled {
-    opacity: var(--globals-disabled-opacity);
-    pointer-events: none;
   }
 }
 

--- a/packages/forms/src/radio/radio.module.css
+++ b/packages/forms/src/radio/radio.module.css
@@ -1,6 +1,8 @@
 @import "@uiid/tokens/semantic/forms.tokens.css";
 
 .radio {
+  composes: disabled from "@uiid/tokens/compositions.module.css";
+
   aspect-ratio: 1;
   border-radius: 100%;
   outline: 0;
@@ -22,11 +24,6 @@
   &:focus-visible {
     outline: var(--globals-outline-width) var(--globals-outline-style) var(--globals-outline-color);
     outline-offset: var(--globals-outline-offset);
-  }
-
-  &:where(:disabled, [disabled], [data-disabled]) {
-    pointer-events: none;
-    opacity: var(--globals-disabled-opacity);
   }
 
   &[data-invalid] {

--- a/packages/forms/src/slider/slider.module.css
+++ b/packages/forms/src/slider/slider.module.css
@@ -1,4 +1,6 @@
 .slider-control {
+  composes: disabled from "@uiid/tokens/compositions.module.css";
+
   flex: 1;
   min-width: 12rem;
   min-height: 1rem;
@@ -19,11 +21,6 @@
   border-radius: 0.25rem;
   background-color: var(--shade-muted);
   user-select: none;
-}
-
-.slider-control:where([data-disabled]) {
-  pointer-events: none;
-  opacity: var(--globals-disabled-opacity);
 }
 
 .slider-thumb {

--- a/packages/forms/src/switch/switch.module.css
+++ b/packages/forms/src/switch/switch.module.css
@@ -1,6 +1,8 @@
 @import "@uiid/tokens/component/switch.tokens.css";
 
 .switch-root {
+  composes: disabled from "@uiid/tokens/compositions.module.css";
+
   position: relative;
   display: flex;
   appearance: none;
@@ -23,11 +25,6 @@
   &[data-checked] {
     background-position-x: 0%;
     background-color: var(--shade-halftone);
-  }
-
-  &:where(:disabled, [disabled], [data-disabled]) {
-    opacity: var(--globals-disabled-opacity);
-    pointer-events: none;
   }
 
   &:focus-visible {

--- a/packages/forms/src/textarea/textarea.module.css
+++ b/packages/forms/src/textarea/textarea.module.css
@@ -1,6 +1,8 @@
 @import "@uiid/tokens/semantic/forms.tokens.css";
 
 .textarea {
+  composes: disabled from "@uiid/tokens/compositions.module.css";
+
   background-color: var(--forms-bg);
   border: var(--globals-border-width) solid var(--forms-border-color);
   border-radius: var(--globals-border-radius);
@@ -23,12 +25,6 @@
   &:focus {
     background-color: var(--forms-bg-focus);
     outline-style: var(--globals-outline-style);
-  }
-
-  /** Disabled */
-  &:where(:disabled, [disabled], [data-disabled]) {
-    pointer-events: none;
-    opacity: var(--globals-disabled-opacity);
   }
 
   /** Invalid */

--- a/packages/interactive/src/accordion/accordion.module.css
+++ b/packages/interactive/src/accordion/accordion.module.css
@@ -1,8 +1,7 @@
 @import "@uiid/tokens/component/accordion.tokens.css";
 
-.accordion-root[data-disabled] {
-  opacity: var(--globals-disabled-opacity);
-  pointer-events: none;
+.accordion-root {
+  composes: disabled from "@uiid/tokens/compositions.module.css";
 }
 
 .accordion-item {

--- a/packages/interactive/src/resizable/resizable.module.css
+++ b/packages/interactive/src/resizable/resizable.module.css
@@ -17,6 +17,8 @@
 }
 
 .resizable-handle {
+  composes: disabled from "@uiid/tokens/compositions.module.css";
+
   position: relative;
   display: flex;
   align-items: center;
@@ -38,11 +40,6 @@
 .resizable-handle:hover,
 .resizable-handle[data-separator]:not([data-separator="inactive"]) {
   background-color: var(--shade-accent);
-}
-
-.resizable-handle[data-disabled] {
-  pointer-events: none;
-  opacity: var(--globals-disabled-opacity);
 }
 
 .resizable-handle-grip {

--- a/packages/interactive/src/sortable/sortable.module.css
+++ b/packages/interactive/src/sortable/sortable.module.css
@@ -5,13 +5,10 @@
 }
 
 .sortable-item-handle {
+  composes: disabled from "@uiid/tokens/compositions.module.css";
+
   all: unset;
   cursor: grab;
-
-  &:disabled {
-    pointer-events: none;
-    opacity: var(--globals-disabled-opacity);
-  }
 
   &[data-dragging] {
     cursor: grabbing;

--- a/packages/navigation/src/sidebar/subcomponents/sidebar-menu-button.module.css
+++ b/packages/navigation/src/sidebar/subcomponents/sidebar-menu-button.module.css
@@ -1,4 +1,6 @@
 .sidebar-menu-button {
+  composes: disabled from "@uiid/tokens/compositions.module.css";
+
   align-items: center;
   border-radius: var(--globals-border-radius);
   display: flex;
@@ -18,11 +20,6 @@
   &:active {
     background-color: var(--shade-accent);
     color: var(--shade-foreground);
-  }
-
-  &:disabled {
-    pointer-events: none;
-    opacity: var(--globals-disabled-opacity);
   }
 
   [data-slot="sidebar-menu"]:has([data-slot="sidebar-menu-action"]) & {

--- a/packages/navigation/src/sidebar/subcomponents/sidebar-menu-sub-button.module.css
+++ b/packages/navigation/src/sidebar/subcomponents/sidebar-menu-sub-button.module.css
@@ -1,4 +1,6 @@
 .sidebar-menu-sub-button {
+  composes: disabled from "@uiid/tokens/compositions.module.css";
+
   color: var(--shade-foreground);
   display: flex;
   min-width: 0;
@@ -17,11 +19,6 @@
   &:active {
     background-color: var(--shade-accent);
     color: var(--shade-foreground);
-  }
-
-  &:disabled {
-    pointer-events: none;
-    opacity: var(--globals-disabled-opacity);
   }
 
   & > svg {

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -26,6 +26,7 @@
   ],
   "exports": {
     "./globals.css": "./src/globals.css",
+    "./compositions.module.css": "./src/compositions.module.css",
     "./schema": {
       "types": "./src/schema/index.ts",
       "import": "./src/schema/index.ts"

--- a/packages/tokens/src/compositions.module.css
+++ b/packages/tokens/src/compositions.module.css
@@ -1,0 +1,6 @@
+@layer uiid.compositions {
+  .disabled:where(:disabled, [disabled], [data-disabled], [aria-disabled="true"]) {
+    opacity: var(--globals-disabled-opacity);
+    pointer-events: none;
+  }
+}

--- a/packages/tokens/src/globals.css
+++ b/packages/tokens/src/globals.css
@@ -1,4 +1,4 @@
-@layer uiid.globals, uiid.tokens, uiid.primitives, uiid.components;
+@layer uiid.globals, uiid.tokens, uiid.primitives, uiid.components, uiid.compositions;
 
 @import "./css/primitives/colors.tokens.css";
 @import "./css/primitives/colors.generated.tokens.css";

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -36,6 +36,12 @@ export default defineConfig({
   resolve: {
     alias: {
       ...uiidAliases,
+      // Hand-written CSS Modules in tokens live at the package root
+      // (src/css/ is gitignored, holds only generated token files).
+      "@uiid/tokens/compositions.module.css": path.resolve(
+        __dirname,
+        "packages/tokens/src/compositions.module.css"
+      ),
       // Resolve @uiid/tokens/* CSS imports to source files
       // This uses a regex to match any .css file under @uiid/tokens/
       "@uiid/tokens": path.resolve(__dirname, "packages/tokens/src/css"),


### PR DESCRIPTION
## Summary

- Add `@uiid/tokens/compositions.module.css` as the shared CSS Modules source for `composes`, owning a `.disabled` class (`opacity: var(--globals-disabled-opacity)` + `pointer-events: none`) covering `:disabled`, `[disabled]`, `[data-disabled]`, and `[aria-disabled="true"]`.
- Add a new `uiid.compositions` layer (highest in the cascade order) so composed state styles reliably win over `uiid.components` consumer rules.
- Convert **14 consumers across 5 packages** to compose this source instead of duplicating the rule: input, checkbox, radio, switch, textarea, slider, number-field's increment + decrement, button, code-editor, sidebar-menu-button, sidebar-menu-sub-button, accordion-root, resizable-handle, sortable-item-handle.
- Add a specific vitest alias so tests resolve `@uiid/tokens/compositions.module.css` from `packages/tokens/src/` (the existing `@uiid/tokens` alias points to `src/css/`, which is gitignored and holds generated output).

## What's NOT included

- `:has(:disabled)` container patterns (`.input-wrapper`, `.checkbox-label`) are deliberately left as-is — they're a different semantic ("element looks disabled when a child is disabled") and would need a separate composition.
- Calendars `event-wrapper` and `.sortable-item` reuse `--globals-disabled-opacity` for `data-dragging`/`data-past-event` states, not disabled — left as-is.

## Test plan

- [ ] `pnpm build` succeeds for all packages
- [ ] `pnpm test:run` passes (888/890, 2 skipped — same as `main`)
- [ ] In each built `.module.css.js`, the consumer's classname export merges the shared `_disabled_*` hash (e.g. `_input_X _disabled_Y`)
- [ ] The same `_disabled_*` hash appears in every consumer across all 5 packages (cross-package `composes` resolution is consistent)
- [ ] The composed rule is wrapped in `@layer uiid.compositions { ... }` in the bundled CSS
- [ ] Visually verify disabled state still works on a sampling of consumers (input, button, checkbox, accordion) in Storybook or docs