### PR TITLE
ci(repo): chunk size-limit by changed package and cache turbo builds

### DIFF
--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -15,6 +15,8 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # need history for [origin/main] filter
 
       - uses: pnpm/action-setup@v4
 
@@ -23,12 +25,86 @@ jobs:
           node-version: 20
           cache: pnpm
 
-      - run: pnpm install
+      - run: pnpm install --frozen-lockfile
 
-      - uses: andresz1/size-limit-action@v1.8.0
+      # Cache turbo outputs across runs so unchanged packages skip rebuild.
+      - uses: actions/cache@v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          package_manager: pnpm
-          build_script: build
-          skip_step: install
-          script: pnpm size-limit --json
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-
+
+      - name: Identify affected packages
+        id: affected
+        run: |
+          # Names of packages changed vs origin/main, including their dependents.
+          NAMES=$(pnpm m ls --filter '...[origin/main]' --depth=-1 --json \
+            | jq -r '.[].name' \
+            | grep -v '^@uiid/design-system$' || true)
+          # Strip trailing newline; emit as space-separated for size-limit args.
+          ARGS=$(echo "$NAMES" | tr '\n' ' ' | sed 's/ *$//')
+          echo "args=$ARGS" >> $GITHUB_OUTPUT
+          if [ -z "$ARGS" ]; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "No package changes — size check skipped."
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+            echo "Affected: $ARGS"
+          fi
+
+      - name: Build affected packages
+        if: steps.affected.outputs.skip != 'true'
+        run: pnpm turbo build --filter='...[origin/main]'
+
+      - name: Run size-limit for affected packages
+        if: steps.affected.outputs.skip != 'true'
+        run: |
+          # size-limit treats positional args as name patterns; quote each one.
+          ARGS=$(printf '"%s" ' ${{ steps.affected.outputs.args }})
+          eval "pnpm size-limit $ARGS --json" > size-report.json
+          cat size-report.json
+
+      - name: Comment results on PR
+        if: steps.affected.outputs.skip != 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const results = JSON.parse(fs.readFileSync('size-report.json', 'utf8'));
+            const fmt = (b) => `${(b / 1024).toFixed(2)} kB`;
+            const rows = results.map(r => {
+              const status = r.passed === false ? ':red_circle:' : ':white_check_mark:';
+              return `| ${status} | \`${r.name}\` | ${fmt(r.size)} | ${r.limit ?? '—'} |`;
+            });
+            const body = [
+              '### Size report (affected packages)',
+              '',
+              '| | Package | Size | Limit |',
+              '|---|---|---|---|',
+              ...rows,
+              '',
+              `_Checked ${results.length} affected package(s). Unchanged packages were not rebuilt._`,
+            ].join('\n');
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const marker = '### Size report (affected packages)';
+            const existing = comments.find(c => c.body?.startsWith(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,7 +1,92 @@
 [
   {
-    "path": "packages/design-system/dist/index.js",
     "name": "@uiid/design-system",
+    "path": "packages/design-system/dist/index.js",
     "limit": "500 kB"
+  },
+  {
+    "name": "@uiid/blocks",
+    "path": "packages/blocks/dist/index.js",
+    "limit": "10 kB"
+  },
+  {
+    "name": "@uiid/buttons",
+    "path": "packages/buttons/dist/index.js",
+    "limit": "60 kB"
+  },
+  {
+    "name": "@uiid/calendars",
+    "path": "packages/calendars/dist/index.js",
+    "limit": "110 kB"
+  },
+  {
+    "name": "@uiid/cards",
+    "path": "packages/cards/dist/index.js",
+    "limit": "25 kB"
+  },
+  {
+    "name": "@uiid/code",
+    "path": "packages/code/dist/index.js",
+    "limit": "180 kB"
+  },
+  {
+    "name": "@uiid/forms",
+    "path": "packages/forms/dist/index.js",
+    "limit": "135 kB"
+  },
+  {
+    "name": "@uiid/icons",
+    "path": "packages/icons/dist/index.js",
+    "limit": "140 kB"
+  },
+  {
+    "name": "@uiid/indicators",
+    "path": "packages/indicators/dist/index.js",
+    "limit": "30 kB"
+  },
+  {
+    "name": "@uiid/interactive",
+    "path": "packages/interactive/dist/index.js",
+    "limit": "120 kB"
+  },
+  {
+    "name": "@uiid/layout",
+    "path": "packages/layout/dist/index.js",
+    "limit": "25 kB"
+  },
+  {
+    "name": "@uiid/lists",
+    "path": "packages/lists/dist/index.js",
+    "limit": "35 kB"
+  },
+  {
+    "name": "@uiid/navigation",
+    "path": "packages/navigation/dist/index.js",
+    "limit": "90 kB"
+  },
+  {
+    "name": "@uiid/overlays",
+    "path": "packages/overlays/dist/index.js",
+    "limit": "100 kB"
+  },
+  {
+    "name": "@uiid/registry",
+    "path": "packages/registry/dist/index.js",
+    "limit": "50 kB"
+  },
+  {
+    "name": "@uiid/tables",
+    "path": "packages/tables/dist/index.js",
+    "limit": "100 kB"
+  },
+  {
+    "name": "@uiid/typography",
+    "path": "packages/typography/dist/index.js",
+    "limit": "25 kB"
+  },
+  {
+    "name": "@uiid/utils",
+    "path": "packages/utils/dist/index.js",
+    "limit": "25 kB"
   }
 ]

--- a/docs/guides/size-limit.md
+++ b/docs/guides/size-limit.md
@@ -1,0 +1,71 @@
+# Size Limit
+
+Every PR runs a per-package bundle-size check. Only packages whose source (or whose dependencies' source) changed vs `main` are built and measured — the rest are skipped. Results show up as a comment on the PR.
+
+---
+
+## Triggers
+
+The `Size Limit` workflow runs on every non-draft PR to `main` (open, reopen, push).
+
+It does **not** run on `main` itself — gating is enforced at PR time.
+
+## How affected packages are detected
+
+The workflow uses pnpm's `[origin/main]` filter, which expands to "packages whose own source changed, plus packages that depend on those." That means:
+
+- Editing `packages/buttons/src/index.ts` → checks `@uiid/buttons` and `@uiid/design-system` (since the umbrella re-exports it).
+- Editing `packages/utils/src/index.ts` → checks `@uiid/utils` and everything that depends on it.
+- Editing `apps/storybook/...` → checks nothing in `packages/`.
+
+If no `packages/*` changes are detected, the workflow exits cleanly with no comment.
+
+## Configuring limits
+
+All limits live in `.size-limit.json` at the repo root. Each entry maps a workspace package name to a measured `dist/index.js` and a hard limit:
+
+```json
+{
+  "name": "@uiid/buttons",
+  "path": "packages/buttons/dist/index.js",
+  "limit": "60 kB"
+}
+```
+
+The `limit` value is the **brotlied, minified, dependency-inlined** size — the same number a real consumer would pay.
+
+### Tightening or relaxing a limit
+
+Run locally to see the current measured size for any package:
+
+```bash
+pnpm build
+pnpm size-limit
+```
+
+Then edit `.size-limit.json` and adjust `limit:`. Conventions:
+
+- **Tightening** (`90 kB` → `75 kB`): always OK, do it whenever the actual size drops meaningfully.
+- **Relaxing**: justify in the PR description. The limit is a contract — raising it means consumers will pay for the new bytes.
+
+## When the gate fails
+
+The PR comment will show which package(s) exceeded their limit. From there:
+
+1. **Unintentional bloat** → investigate (new dep? lost tree-shake? barrel re-export of a heavy lib?) and fix.
+2. **Intentional growth** → tighten the change to the smallest reasonable surface, then bump the limit in the same PR with a one-line rationale.
+3. **Wrong limit** → if the existing limit was set too tightly during initial calibration, bump it. Note it as calibration, not bloat.
+
+Running `pnpm size-limit --why` locally produces a webpack-style bundle analyzer report — useful for figuring out what's pulling weight.
+
+## Packages not gated
+
+Three packages are intentionally excluded:
+
+| Package | Reason |
+|---|---|
+| `@uiid/mcp` | Node-target server — uses `node:process` and top-level await. Not a browser bundle. |
+| `@uiid/tokens` | Source-only — ships CSS and TS schema, no `dist/` JS bundle. |
+| `@uiid/themes` | Source-only — ships `src/` directly via subpath exports. |
+
+Tokens and themes still contribute to consumer bundle size; their impact shows up indirectly inside whichever consumer package imports them.


### PR DESCRIPTION
## Summary
- Replaces `andresz1/size-limit-action` (which builds main + PR back-to-back across the entire monorepo) with a workflow that uses turbo's `[origin/main]` affected filter and caches `.turbo/` between runs. PRs that touch one package should rebuild only that package and its dependents.
- Expands `.size-limit.json` from a single umbrella entry to **18 per-package entries** with limits set to measured bundled size + ~20-30% headroom. PR comment now reports per-package results in a markdown table.
- Adds `docs/guides/size-limit.md` covering triggers, how affected detection works, how to tighten/relax limits, and how to handle a failing gate.

## Why
The previous workflow took **6+ minutes** on every PR — driven by a double full-monorepo build with no turbo cache. It also reported a single aggregate size for `@uiid/design-system`, hiding which package was actually changing.

## Excluded packages
- `@uiid/mcp` — Node-target server (top-level await + `node:process`), wrong tool for browser bundle gating.
- `@uiid/tokens`, `@uiid/themes` — source-only packages, no `dist/` JS bundle. Their cost shows up inside consumers.

## Tradeoffs
- **No more main-vs-PR diff column.** The gate is now "PR vs configured limit" rather than "PR vs main". The `limit:` field IS the contract; a diff is a follow-up if useful.
- **First PR after merge pays the full first-time-cache-miss cost** (~same as today). Subsequent PRs should be much faster.
- Initial limits are calibrated to current measured sizes — see `docs/guides/size-limit.md` for how to tighten as bundles improve.

## Checklist
- [ ] First CI run on this PR posts a per-package size report comment
- [ ] `pnpm m ls --filter '...[origin/main]'` correctly identifies changed packages on the runner (verify by inspecting workflow logs)
- [ ] All 18 size-limit entries pass on the runner (locally: pass)
- [ ] `.turbo/` cache hit rate improves on a follow-up PR
- [ ] Old monolithic check is gone from the PR status list (workflow name unchanged: "Size Limit")