### PR TITLE
ci(repo): fix size-limit by filtering config, not positional args

### DIFF
--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -35,22 +35,25 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-turbo-
 
-      - name: Identify affected packages
+      - name: Build affected size-limit config
         id: affected
         run: |
           # Names of packages changed vs origin/main, including their dependents.
           NAMES=$(pnpm m ls --filter '...[origin/main]' --depth=-1 --json \
             | jq -r '.[].name' \
             | grep -v '^@uiid/design-system$' || true)
-          # Strip trailing newline; emit as space-separated for size-limit args.
-          ARGS=$(echo "$NAMES" | tr '\n' ' ' | sed 's/ *$//')
-          echo "args=$ARGS" >> $GITHUB_OUTPUT
-          if [ -z "$ARGS" ]; then
+          # Keep only entries that exist in .size-limit.json (mcp, tokens, apps are skipped).
+          jq --argjson names "$(echo "$NAMES" | jq -R . | jq -s .)" \
+            '[.[] | select(.name as $n | $names | index($n))]' \
+            .size-limit.json > .size-limit.filtered.json
+          COUNT=$(jq 'length' .size-limit.filtered.json)
+          if [ "$COUNT" -eq 0 ]; then
             echo "skip=true" >> $GITHUB_OUTPUT
-            echo "No package changes — size check skipped."
+            echo "No measured packages affected — size check skipped."
           else
             echo "skip=false" >> $GITHUB_OUTPUT
-            echo "Affected: $ARGS"
+            echo "Measuring $COUNT package(s):"
+            jq -r '.[].name' .size-limit.filtered.json
           fi
 
       - name: Build affected packages
@@ -59,11 +62,7 @@ jobs:
 
       - name: Run size-limit for affected packages
         if: steps.affected.outputs.skip != 'true'
-        run: |
-          # size-limit treats positional args as name patterns; quote each one.
-          ARGS=$(printf '"%s" ' ${{ steps.affected.outputs.args }})
-          eval "pnpm size-limit $ARGS --json" > size-report.json
-          cat size-report.json
+        run: pnpm size-limit --config .size-limit.filtered.json --json > size-report.json && cat size-report.json
 
       - name: Comment results on PR
         if: steps.affected.outputs.skip != 'true'


### PR DESCRIPTION
## Summary

- `size-limit` treats positional CLI args as file paths, not name patterns. The workflow merged in #215 passed affected package names positionally and failed every run with `Could not resolve "/.../@uiid/utils"` etc., visible on PR #211.
- Filter `.size-limit.json` with `jq` to keep only entries whose `name` is in the affected list, write to `.size-limit.filtered.json`, and pass it via `--config`.
- Also cleanly drops `@uiid/mcp`, `@uiid/tokens`, and the app workspaces (`blocks`, `docs`, `@uiid/storybook`) which were in the affected output but not in `.size-limit.json`.

## Why the previous approach failed

Looking at the failed run on PR #211:

```
Affected: @uiid/blocks blocks @uiid/mcp @uiid/buttons docs @uiid/calendars @uiid/storybook @uiid/code @uiid/forms @uiid/interactive @uiid/tables @uiid/navigation @uiid/registry @uiid/cards @uiid/indicators @uiid/overlays @uiid/icons @uiid/layout @uiid/lists @uiid/tokens @uiid/typography @uiid/utils
...
eval "pnpm size-limit "@uiid/blocks" "blocks" "@uiid/mcp" ... --json"
...
✘ [ERROR] Could not resolve "/home/runner/work/design-system/design-system/@uiid/utils"
✘ [ERROR] Could not resolve "/home/runner/work/design-system/design-system/blocks"
...
```

The inline comment in the workflow claimed *"size-limit treats positional args as name patterns"* — it doesn't. Confirmed against the `ai/size-limit` docs: positional args are file paths to add to the check, not a name filter.

## Test plan

- [ ] Size Limit workflow passes on this PR (no `@uiid/*` packages should be affected here — the workflow's filtered-config step should report 0 entries and skip cleanly).
- [ ] Once merged, re-run Size Limit on PR #211 to confirm green.
- [ ] Local: pre-push hook ran `pnpm size-limit` against the full config — all 18 entries reported under their limits.