### PR TITLE
feat(storybook): alias @uiid/* to source for HMR

### DIFF
--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -1,5 +1,6 @@
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
+import { readdirSync, existsSync, readFileSync } from "node:fs";
 import type { StorybookConfig } from "@storybook/react-vite";
 import { applyPostCSSLayers } from "../src/utils/postcss-config.ts";
 
@@ -22,12 +23,30 @@ const config: StorybookConfig = {
   },
   async viteFinal(config) {
     const __dirname = dirname(fileURLToPath(import.meta.url));
+    const packagesDir = resolve(__dirname, "../../../packages");
+    const sourcePackages = getUiidSourcePackages(packagesDir);
 
     if (!config.resolve) config.resolve = {};
-    config.resolve.alias = {
-      ...config.resolve.alias,
-      "@tokens": resolve(__dirname, "../../../packages/tokens/src"),
-    };
+
+    // Exact-match aliases so `@uiid/<pkg>` resolves to source while
+    // subpath imports (e.g. `@uiid/<pkg>/globals.css`) keep using the
+    // package's `exports` field. Array form lets us use regex anchors.
+    const existingAliases = normalizeAliasArray(config.resolve.alias);
+    config.resolve.alias = [
+      ...sourcePackages.map(({ name, entry }) => ({
+        find: new RegExp(`^${escapeRegex(name)}$`),
+        replacement: entry,
+      })),
+      { find: "@tokens", replacement: resolve(packagesDir, "tokens/src") },
+      ...existingAliases,
+    ];
+
+    // Workspace packages now point at source — don't let Vite pre-bundle them.
+    if (!config.optimizeDeps) config.optimizeDeps = {};
+    config.optimizeDeps.exclude = [
+      ...(config.optimizeDeps.exclude ?? []),
+      ...sourcePackages.map(({ name }) => name),
+    ];
 
     return applyPostCSSLayers(config);
   },
@@ -37,4 +56,41 @@ export default config;
 
 function getAbsolutePath(value: string): any {
   return dirname(fileURLToPath(import.meta.resolve(`${value}/package.json`)));
+}
+
+type SourcePackage = { name: string; entry: string };
+
+function getUiidSourcePackages(packagesDir: string): SourcePackage[] {
+  const result: SourcePackage[] = [];
+  for (const dir of readdirSync(packagesDir, { withFileTypes: true })) {
+    if (!dir.isDirectory()) continue;
+    const pkgPath = resolve(packagesDir, dir.name, "package.json");
+    if (!existsSync(pkgPath)) continue;
+    const pkg = JSON.parse(readFileSync(pkgPath, "utf8")) as { name?: string };
+    if (!pkg.name?.startsWith("@uiid/")) continue;
+    const srcTs = resolve(packagesDir, dir.name, "src/index.ts");
+    const srcTsx = resolve(packagesDir, dir.name, "src/index.tsx");
+    const entry = existsSync(srcTs)
+      ? srcTs
+      : existsSync(srcTsx)
+        ? srcTsx
+        : null;
+    if (!entry) continue;
+    result.push({ name: pkg.name, entry });
+  }
+  return result;
+}
+
+function normalizeAliasArray(
+  alias: unknown,
+): Array<{ find: string | RegExp; replacement: string }> {
+  if (!alias) return [];
+  if (Array.isArray(alias)) return alias;
+  return Object.entries(alias as Record<string, string>).map(
+    ([find, replacement]) => ({ find, replacement }),
+  );
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }


### PR DESCRIPTION
## Summary
- Storybook's `viteFinal` now aliases every `@uiid/*` workspace package to its `src/index.{ts,tsx}` entry, using regex anchors so only bare specifiers match. Subpath imports (`@uiid/<pkg>/globals.css`, etc.) keep using each package's `exports` field.
- Adds the same packages to `optimizeDeps.exclude` so Vite doesn't pre-bundle them — keeps HMR live across the monorepo without rebuilding individual packages.

## Why
Previously, iterating on a component required running its package build before Storybook would see the change. With these aliases Storybook serves source directly, so edits in any UIID package hot-reload immediately.

## Test plan
- [x] `pnpm run storybook` — confirmed source edits (e.g. `packages/buttons/src/button.tsx`, CSS modules) hot-reload without a separate build
- [x] Subpath imports still resolve (`@uiid/tokens/globals.css`, etc.)