### PR TITLE
feat(ui): tighten Badge sizing to feel sane at small

### DIFF
--- a/.changeset/badge-sizing.md
+++ b/.changeset/badge-sizing.md
@@ -1,0 +1,6 @@
+---
+"@uiid/indicators": patch
+"@uiid/tokens": patch
+---
+
+Tighten `Badge` sizing to feel sane at `small`. Reduces padding-y across all sizes (small `0.375rem` → `0.125rem`), trims padding-x on medium/large, drops border-radius from `0.5rem` → `0.375rem`, and adds a new `--badge-line-height` token (`1.25`) applied to both `.badge` and `.badge-text` so the inner `<Text>` no longer forces 1.5 line-height padding into the box. The small badge now lands around 18–20px tall — proportional to shadcn's default badge.

--- a/packages/indicators/src/badge/badge.module.css
+++ b/packages/indicators/src/badge/badge.module.css
@@ -9,6 +9,11 @@
   color: var(--badge-fg);
   display: inline-flex !important;
   border-radius: var(--badge-border-radius);
+  line-height: var(--badge-line-height);
+}
+
+.badge-text {
+  line-height: var(--badge-line-height);
 }
 
 .badge-indicator {

--- a/packages/tokens/src/json/component/badge.tokens.json
+++ b/packages/tokens/src/json/component/badge.tokens.json
@@ -2,19 +2,20 @@
   "$description": "UIID Design System - Badge Component Tokens",
   "$schema": "../../../dtcg.schema.json",
   "badge": {
-    "border-radius": { "$value": "0.5rem", "$type": "dimension" },
+    "border-radius": { "$value": "0.375rem", "$type": "dimension" },
+    "line-height": { "$value": "1.25", "$type": "number" },
     "size": {
       "sm": {
         "padding-x": { "$value": "0.5rem", "$type": "dimension" },
-        "padding-y": { "$value": "0.375rem", "$type": "dimension" }
+        "padding-y": { "$value": "0.125rem", "$type": "dimension" }
       },
       "md": {
-        "padding-x": { "$value": "0.75rem", "$type": "dimension" },
-        "padding-y": { "$value": "0.5rem", "$type": "dimension" }
+        "padding-x": { "$value": "0.625rem", "$type": "dimension" },
+        "padding-y": { "$value": "0.25rem", "$type": "dimension" }
       },
       "lg": {
-        "padding-x": { "$value": "1rem", "$type": "dimension" },
-        "padding-y": { "$value": "0.75rem", "$type": "dimension" }
+        "padding-x": { "$value": "0.75rem", "$type": "dimension" },
+        "padding-y": { "$value": "0.375rem", "$type": "dimension" }
       }
     }
   }


### PR DESCRIPTION
## Summary

- Reduces padding-y across all Badge sizes (small from `0.375rem` → `0.125rem`); trims padding-x on medium/large.
- Drops `--badge-border-radius` from `0.5rem` → `0.375rem` (shadcn's `rounded-md`).
- Adds a new `--badge-line-height` token (`1.25`) and applies it to both `.badge` and `.badge-text` so the inner `<Text>` no longer pushes 1.5 line-height padding into the box.

At `Text size={-1}` (12px) + line-height 1.25, the new small badge lands around 18–20px tall — proportional to shadcn's default badge instead of feeling like a small button.

| Token | Before | After |
| --- | --- | --- |
| border-radius | `0.5rem` | `0.375rem` |
| line-height | (inherited 1.5) | `1.25` (new) |
| small padding-y | `0.375rem` | `0.125rem` |
| medium padding-y | `0.5rem` | `0.25rem` |
| large padding-y | `0.75rem` | `0.375rem` |

Downstream callers (`event-calendar` uses `size="large"`) will now render noticeably tighter chips — visual check recommended.

## Test plan

- [ ] Storybook → Indicators / Badge → all three sizes look proportional (small ≈ shadcn)
- [ ] Storybook → Calendars / Event Calendar → event chips still readable; not under-padded
- [ ] 873 unit tests still pass (`pnpm test:run`)