### PR TITLE
feat(ui): polish Card header shape and lift sizing to tokens

### DIFF
--- a/.changeset/card-polish.md
+++ b/.changeset/card-polish.md
@@ -1,0 +1,6 @@
+---
+"@uiid/cards": patch
+"@uiid/tokens": patch
+---
+
+Polish `Card`: rebuild header conditional rendering so empty cells and the inner container no longer reserve phantom space. Move description out of the title lockup; the header + description are wrapped in a `Stack(gap=2)` only when both are present. Lift icon and header-cell sizing into CSS via `--card-icon-size` and drop `card.constants.ts`. Remove the orphan `size` variant — the `--card-size-*-max-width` CSS references never matched the sm/md/lg tokens and no consumer used it. `CardTitle` drops inline `minHeight`/`alignContent` and switches `weight` from `bold` to `semibold`. `CardFooter` gains a leading `Separator`.

--- a/apps/storybook/stories/cards/card.stories.tsx
+++ b/apps/storybook/stories/cards/card.stories.tsx
@@ -49,6 +49,69 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = { name: "Card" };
 
+const HEADER_VARIANTS = [
+  { label: "No header", props: {} },
+  { label: "Title only", props: { title: "Title only" } },
+  { label: "Description only", props: { description: "Description only" } },
+  {
+    label: "Title + description",
+    props: { title: "Title", description: "And a description" },
+  },
+  { label: "Icon only", props: { icon: Globe } },
+  { label: "Icon + title", props: { icon: Globe, title: "Icon + title" } },
+  {
+    label: "Action only",
+    props: { action: <button>Action</button> },
+  },
+  {
+    label: "Title + action",
+    props: { title: "Title + action", action: <button>Action</button> },
+  },
+  {
+    label: "Icon + title + action",
+    props: {
+      icon: Globe,
+      title: "Icon + title + action",
+      action: <button>Action</button>,
+    },
+  },
+  {
+    label: "Full header",
+    props: {
+      icon: Globe,
+      title: "Full header",
+      description: "Icon, title, description, and action all present",
+      action: <button>Action</button>,
+    },
+  },
+] as const;
+
+export const HeaderVariants: Story = {
+  name: "Header Variants",
+  parameters: { controls: { disable: true } },
+  render: () => (
+    <Stack gap={4} style={{ maxWidth: "30rem" }}>
+      {HEADER_VARIANTS.map((v) => (
+        <Card key={v.label} {...v.props}>
+          {`Body for: ${v.label}`}
+        </Card>
+      ))}
+    </Stack>
+  ),
+};
+
+export const HeaderVariantsNoBody: Story = {
+  name: "Header Variants (no body)",
+  parameters: { controls: { disable: true } },
+  render: () => (
+    <Stack gap={4} style={{ maxWidth: "30rem" }}>
+      {HEADER_VARIANTS.map((v) => (
+        <Card key={v.label} {...v.props} />
+      ))}
+    </Stack>
+  ),
+};
+
 const PlaceholderThumbnail = () => (
   <svg
     viewBox="0 0 300 300"

--- a/packages/cards/src/card/card.constants.ts
+++ b/packages/cards/src/card/card.constants.ts
@@ -1,4 +1,0 @@
-export const ICON_SIZE = 18;
-export const ICON_STROKE = 2;
-
-export const CARD_DEFAULT_GAP = 3;

--- a/packages/cards/src/card/card.module.css
+++ b/packages/cards/src/card/card.module.css
@@ -48,9 +48,17 @@
   }
 }
 
-.card-action {
-  margin-inline-start: auto;
+.card-header-cell {
+  min-height: calc(var(--card-icon-size) * 1.5);
+}
 
+.card-icon {
+  width: var(--card-icon-size);
+  height: auto;
+  flex-shrink: 0;
+}
+
+.card-action {
   svg {
     width: var(--card-icon-size);
     height: auto;
@@ -78,16 +86,4 @@
 
 .toggle-transparent {
   background-color: transparent;
-}
-
-.size-small {
-  max-width: var(--card-size-small-max-width);
-}
-
-.size-medium {
-  max-width: var(--card-size-medium-max-width);
-}
-
-.size-large {
-  max-width: var(--card-size-large-max-width);
 }

--- a/packages/cards/src/card/card.tsx
+++ b/packages/cards/src/card/card.tsx
@@ -1,4 +1,5 @@
 import { ConditionalRender, Stack, type StackProps } from "@uiid/layout";
+import { cx } from "@uiid/utils";
 
 import type { CardProps } from "./card.types";
 
@@ -12,7 +13,7 @@ import {
   CardFooter,
   CardThumbnail,
 } from "./subcomponents";
-import { ICON_SIZE } from "./card.constants";
+import styles from "./card.module.css";
 
 export const Card = ({
   title,
@@ -21,7 +22,6 @@ export const Card = ({
   icon,
   action,
   footer,
-  size,
   ContainerProps,
   HeaderProps,
   TitleProps,
@@ -39,36 +39,57 @@ export const Card = ({
   const Action = ActionProps?.children || action;
   const Icon = IconProps?.icon || icon;
 
+  const hasIcon = Boolean(Icon);
+  const hasTitle = Boolean(Title);
+  const hasAction = Boolean(Action);
+  const hasDescription = Boolean(Description);
+  const hasHeader = hasIcon || hasTitle || hasAction;
+
   return (
-    <CardContainer size={size} {...props} {...ContainerProps}>
+    <CardContainer {...props} {...ContainerProps}>
       {thumbnail && (
         <CardThumbnail mb={2} {...ThumbnailProps}>
           {thumbnail}
         </CardThumbnail>
       )}
 
-      <ConditionalRender
-        condition={Boolean(title || icon || action)}
-        render={<CardHeader {...HeaderProps} />}
-      >
-        <Container>{Icon && <CardIcon icon={Icon} {...IconProps} />}</Container>
-
-        <Container>
-          {Title && <CardTitle {...TitleProps}>{Title}</CardTitle>}
-          {Description && (
+      {(hasHeader || hasDescription) && (
+        <ConditionalRender
+          condition={hasHeader && hasDescription}
+          render={<Stack gap={2} fullwidth />}
+        >
+          {hasHeader && (
+            <CardHeader {...HeaderProps}>
+              {hasIcon && (
+                <Container>
+                  <CardIcon icon={Icon} {...IconProps} />
+                </Container>
+              )}
+              {hasTitle && (
+                <Container>
+                  <CardTitle {...TitleProps}>{Title}</CardTitle>
+                </Container>
+              )}
+              {hasAction && (
+                <Container ml="auto">
+                  <CardAction {...ActionProps}>{Action}</CardAction>
+                </Container>
+              )}
+            </CardHeader>
+          )}
+          {hasDescription && (
             <CardDescription {...DescriptionProps}>
               {Description}
             </CardDescription>
           )}
-        </Container>
-        <Container ml="auto">
-          {Action && <CardAction {...ActionProps}>{Action}</CardAction>}
-        </Container>
-      </ConditionalRender>
+        </ConditionalRender>
+      )}
 
-      <Stack data-slot="card-inner-container" my={2} {...InnerContainerProps}>
-        {children}
-      </Stack>
+      {children && (
+        <Stack data-slot="card-inner-container" my={2} {...InnerContainerProps}>
+          {children}
+        </Stack>
+      )}
 
       {footer && <CardFooter {...FooterProps}>{footer}</CardFooter>}
     </CardContainer>
@@ -76,8 +97,12 @@ export const Card = ({
 };
 Card.displayName = "Card";
 
-const Container = ({ children, ...props }: StackProps) => (
-  <Stack minh={ICON_SIZE * 1.5} ay="center" {...props}>
+const Container = ({ children, className, ...props }: StackProps) => (
+  <Stack
+    className={cx(styles["card-header-cell"], className)}
+    ay="center"
+    {...props}
+  >
     {children}
   </Stack>
 );

--- a/packages/cards/src/card/card.types.ts
+++ b/packages/cards/src/card/card.types.ts
@@ -21,7 +21,7 @@ export type CardFooterProps = GroupProps;
 export type CardThumbnailProps = StackProps;
 export type InnerContainerProps = StackProps;
 
-export type CardProps = Omit<StackProps, "size" | "title"> &
+export type CardProps = Omit<StackProps, "title"> &
   CardVariantProps & {
     title?: React.ReactNode;
     description?: React.ReactNode;

--- a/packages/cards/src/card/card.variants.ts
+++ b/packages/cards/src/card/card.variants.ts
@@ -8,10 +8,5 @@ export const cardVariants = cva({
     trimmed: { true: styles["toggle-trimmed"] },
     transparent: { true: styles["toggle-transparent"] },
     ghost: { true: styles["toggle-ghost"] },
-    size: {
-      small: styles["size-small"],
-      medium: styles["size-medium"],
-      large: styles["size-large"],
-    },
   },
 });

--- a/packages/cards/src/card/subcomponents/card-container.tsx
+++ b/packages/cards/src/card/subcomponents/card-container.tsx
@@ -1,18 +1,16 @@
 import { Stack } from "@uiid/layout";
 import { cx } from "@uiid/utils";
 
-import { CARD_DEFAULT_GAP } from "../card.constants";
 import type { CardContainerProps } from "../card.types";
 import { cardVariants } from "../card.variants";
 import styles from "../card.module.css";
 
 export const CardContainer = ({
-  gap = CARD_DEFAULT_GAP,
+  gap = 3,
   trimmed,
   transparent,
   ghost,
   inverted,
-  size,
   className,
   children,
   ...props
@@ -23,7 +21,7 @@ export const CardContainer = ({
       gap={gap}
       className={cx(
         styles["card"],
-        cardVariants({ trimmed, transparent, ghost, inverted, size }),
+        cardVariants({ trimmed, transparent, ghost, inverted }),
         className,
       )}
       {...props}

--- a/packages/cards/src/card/subcomponents/card-footer.tsx
+++ b/packages/cards/src/card/subcomponents/card-footer.tsx
@@ -1,12 +1,15 @@
-import { Group } from "@uiid/layout";
+import { Group, Separator } from "@uiid/layout";
 
 import type { CardFooterProps } from "../card.types";
 
 export const CardFooter = ({ children, ...props }: CardFooterProps) => {
   return (
-    <Group data-slot="card-footer" gap={2} fullwidth {...props}>
-      {children}
-    </Group>
+    <>
+      <Separator />
+      <Group data-slot="card-footer" gap={2} fullwidth {...props}>
+        {children}
+      </Group>
+    </>
   );
 };
 CardFooter.displayName = "CardFooter";

--- a/packages/cards/src/card/subcomponents/card-icon.tsx
+++ b/packages/cards/src/card/subcomponents/card-icon.tsx
@@ -1,22 +1,22 @@
 import { ConditionalRender } from "@uiid/layout";
+import { cx } from "@uiid/utils";
 
-import { ICON_SIZE, ICON_STROKE } from "../card.constants";
 import type { CardIconProps } from "../card.types";
+import styles from "../card.module.css";
 
 export const CardIcon = ({
   icon: IconProp,
   render,
   className,
 }: CardIconProps) => {
-  const iconProps = {
-    size: ICON_SIZE,
-    strokeWidth: ICON_STROKE,
-    className,
-  };
-
   return (
     <ConditionalRender condition={!!render} render={render!}>
-      {IconProp ? <IconProp {...iconProps} /> : null}
+      {IconProp ? (
+        <IconProp
+          data-slot="card-icon"
+          className={cx(styles["card-icon"], className)}
+        />
+      ) : null}
     </ConditionalRender>
   );
 };

--- a/packages/cards/src/card/subcomponents/card-title.tsx
+++ b/packages/cards/src/card/subcomponents/card-title.tsx
@@ -1,16 +1,14 @@
 import { Text } from "@uiid/typography";
 
-import { ICON_SIZE } from "../card.constants";
 import type { CardTitleProps } from "../card.types";
 
-export const CardTitle = ({ children, style, ...props }: CardTitleProps) => {
+export const CardTitle = ({ children, ...props }: CardTitleProps) => {
   return (
     <Text
       data-slot="card-title"
       render={<h3 />}
-      style={{ minHeight: `${ICON_SIZE}px`, alignContent: "center", ...style }}
       size={1}
-      weight="bold"
+      weight="semibold"
       {...props}
     >
       {children}

--- a/packages/tokens/src/json/component/card.tokens.json
+++ b/packages/tokens/src/json/component/card.tokens.json
@@ -4,12 +4,6 @@
   "card": {
     "icon-size": { "$value": "1rem", "$type": "dimension" },
     "scale-up": { "$value": 1.02, "$type": "number" },
-    "scale-down": { "$value": 0.99, "$type": "number" },
-    "size": {
-      "$type": "dimension",
-      "sm": { "$value": "24rem" },
-      "md": { "$value": "32rem" },
-      "lg": { "$value": "48rem" }
-    }
+    "scale-down": { "$value": 0.99, "$type": "number" }
   }
 }


### PR DESCRIPTION
## Summary

- Rebuild Card header conditional rendering so empty cells, the inner container, and the header itself no longer reserve phantom space when slots are empty.
- Move `description` out of the title lockup; when both header and description are present, they wrap in `<Stack gap={2}>`. Otherwise no extra wrapper.
- Lift icon and header-cell sizing into `card.module.css` via `--card-icon-size`; delete `card.constants.ts` (`ICON_SIZE`/`ICON_STROKE`/`CARD_DEFAULT_GAP`).
- Drop the orphan `size` variant from Card. No consumer used it, and the `--card-size-*-max-width` CSS references didn't match the `sm/md/lg` tokens in `card.tokens.json`. Removed the size token group too.
- `CardTitle`: drop inline `style={{ minHeight, alignContent }}` (parent cell handles row height); switch weight `bold` → `semibold`.
- `CardFooter`: add a leading `<Separator />`.
- `card-action`: drop `margin-inline-start: auto` from CSS; positioning now owned by the `ml="auto"` prop on the wrapping cell (props-first).
- Storybook: new `HeaderVariants` and `HeaderVariants (no body)` stories covering every header combination.

## Test plan

- [ ] Storybook → Cards / Card / Header Variants: each combination renders with the correct shape (no phantom space for empty slots; description-only renders just the description).
- [ ] Storybook → Cards / Card / Header Variants (no body): inner container no longer adds vertical space when `children` is absent.
- [ ] Overlays (Modal, Sheet, Drawer, Popover, Tooltip, Toast) still render correctly — they wrap `<Card>` but never relied on its `size` variant.
- [ ] `pnpm test:run` passes.
- [ ] `pnpm size` within expected bounds.