### PR TITLE
fix(ui): render plain code as a fallback while shiki loads

### DIFF
--- a/.changeset/code-block-fouc-fallback.md
+++ b/.changeset/code-block-fouc-fallback.md
@@ -1,0 +1,5 @@
+---
+"@uiid/code": patch
+---
+
+Fixed a flash of unstyled content during the (unavoidable) async shiki load: `CodeBlockContent` now renders the raw `code` as a styled `<pre><code>` with per-line spans while highlighting is pending, then swaps to the highlighted HTML in place. Identical layout, only token colors fill in.

--- a/packages/code/src/code-block/code-block.module.css
+++ b/packages/code/src/code-block/code-block.module.css
@@ -97,16 +97,11 @@
   }
 }
 
-.code-block-loading,
 .code-block-error {
   font-family: var(--code-font-family);
   font-size: var(--code-font-size);
-  color: var(--shade-muted);
-  padding: var(--code-padding);
-}
-
-.code-block-error {
   color: var(--theme-critical-foreground);
+  padding: var(--code-padding);
 }
 
 .code-block-expand-toggle {

--- a/packages/code/src/code-block/code-block.tsx
+++ b/packages/code/src/code-block/code-block.tsx
@@ -42,10 +42,10 @@ export const CodeBlock = ({
     [onWrapChange],
   );
 
-  const { html, loading, error } = useHighlight(code, language, {
+  const { html, error } = useHighlight(code, language, {
     highlightLines,
   });
-  const displayHtml = prerenderedHtml || html;
+  const displayHtml = prerenderedHtml || html || undefined;
 
   const [expanded, setExpanded] = React.useState(defaultExpanded);
   const [overflows, setOverflows] = React.useState(false);
@@ -95,14 +95,19 @@ export const CodeBlock = ({
         {...HeaderProps}
       />
 
-      {loading && !prerenderedHtml && (
-        <div
-          data-slot="code-block-loading"
-          className={styles["code-block-loading"]}
-        >
-          [Loading...]
-        </div>
-      )}
+      <div
+        ref={contentWrapperRef}
+        data-slot="code-block-scroll"
+        className={styles["code-block-scroll"]}
+        style={wrapperStyle}
+      >
+        <CodeBlockContent
+          html={displayHtml}
+          code={code}
+          showLineNumbers={showLineNumbers}
+          wrap={wrap}
+        />
+      </div>
 
       {error && !prerenderedHtml && (
         <div
@@ -110,21 +115,6 @@ export const CodeBlock = ({
           className={styles["code-block-error"]}
         >
           [Error: {error.message}]
-        </div>
-      )}
-
-      {displayHtml && (
-        <div
-          ref={contentWrapperRef}
-          data-slot="code-block-scroll"
-          className={styles["code-block-scroll"]}
-          style={wrapperStyle}
-        >
-          <CodeBlockContent
-            html={displayHtml}
-            showLineNumbers={showLineNumbers}
-            wrap={wrap}
-          />
         </div>
       )}
 

--- a/packages/code/src/code-block/code-block.types.ts
+++ b/packages/code/src/code-block/code-block.types.ts
@@ -39,8 +39,10 @@ export type CodeBlockHeaderProps = GroupProps & {
 };
 
 export type CodeBlockContentProps = StackProps & {
-  /** HTML content to render */
-  html: string;
+  /** Highlighted HTML content from shiki (preferred when available) */
+  html?: string;
+  /** Raw code, rendered as a fallback while highlighting is async-pending */
+  code?: string;
   /** Show line numbers */
   showLineNumbers?: boolean;
   /** Soft-wrap long lines instead of horizontal scroll */

--- a/packages/code/src/code-block/subcomponents/code-block-content.tsx
+++ b/packages/code/src/code-block/subcomponents/code-block-content.tsx
@@ -8,27 +8,54 @@ import styles from "../code-block.module.css";
 
 export const CodeBlockContent = ({
   html,
+  code,
   showLineNumbers = DEFAULT_SHOW_LINE_NUMBERS,
   wrap = DEFAULT_WRAP,
   className,
   ...props
 }: CodeBlockContentProps) => {
+  const sharedClass = cx(
+    styles["code-block-content"],
+    wrap && styles["code-block-content-wrap"],
+    codeContentVariants({ showLineNumbers }),
+    className,
+  );
+  const sharedAttrs = {
+    "data-slot": "code-block-content",
+    "data-line-numbers": showLineNumbers || undefined,
+    "data-wrap": wrap || undefined,
+    ax: "stretch" as const,
+    fullwidth: true,
+  };
+
+  // Highlighted (shiki) path — preferred when html is available.
+  if (html) {
+    return (
+      <Stack
+        {...sharedAttrs}
+        className={sharedClass}
+        dangerouslySetInnerHTML={{ __html: html }}
+        {...props}
+      />
+    );
+  }
+
+  // Unhighlighted fallback — same layout, no syntax colors. Used until the
+  // highlighter finishes its async work so users don't see a flash of empty
+  // space (or a "Loading..." string).
+  const lines = (code ?? "").split("\n");
   return (
-    <Stack
-      data-slot="code-block-content"
-      data-line-numbers={showLineNumbers || undefined}
-      data-wrap={wrap || undefined}
-      className={cx(
-        styles["code-block-content"],
-        wrap && styles["code-block-content-wrap"],
-        codeContentVariants({ showLineNumbers }),
-        className
-      )}
-      dangerouslySetInnerHTML={{ __html: html }}
-      ax="stretch"
-      fullwidth
-      {...props}
-    />
+    <Stack {...sharedAttrs} className={sharedClass} {...props}>
+      <pre>
+        <code>
+          {lines.map((line, i) => (
+            <span key={i} className="line">
+              {line || " "}
+            </span>
+          ))}
+        </code>
+      </pre>
+    </Stack>
   );
 };
 CodeBlockContent.displayName = "CodeBlockContent";


### PR DESCRIPTION
## Summary

Salvages the orphaned FOUC fix from `code-block-polish` — the rest of that branch shipped as #221, but this follow-up commit (`de3300d3`) never made it.

Shiki (themes + languages) is dynamically imported, so on initial paint the highlighter is not ready and `useHighlight` resolves async. The previous fallback rendered an empty `Stack` (effectively invisible); a recent pass swapped that for visible `[Loading...]` text, which read as a flash of unstyled content.

Replaces the loading placeholder with a styled-but-uncolored `<pre><code>` built from the raw `code` prop — same monospace, padding, and per-line span structure as shiki's output. When highlight resolves, `CodeBlockContent` swaps to the `dangerouslySetInnerHTML` path with the shiki HTML. Layout stays identical; users see correctly framed code immediately, with syntax colors filling in once shiki's chunks land.

`CodeBlockContent` now accepts either `html` (preferred) or `code` (fallback). `CodeBlock` always passes both so the fallback can show on first paint and the highlighted version takes over seamlessly. Drops the now-unused `[Loading...]` element and `.code-block-loading` rule.

## Test plan

- [ ] Hard-reload a docs page with a `CodeBlock` and confirm the layout is stable from first paint (no visible empty Stack, no `[Loading...]` text)
- [ ] Once shiki resolves, confirm the highlighted version swaps in without a layout shift
- [ ] Wrap toggle / expand / copy still work post-swap