### PR TITLE
chore(ui): trim buttons package and adopt examples-driven stories

### DIFF
--- a/.changeset/trim-buttons-package.md
+++ b/.changeset/trim-buttons-package.md
@@ -1,0 +1,6 @@
+---
+"@uiid/buttons": patch
+"@uiid/tokens": patch
+---
+
+Trim the buttons package: rewrite both READMEs (button, toggle-button) in short-form, add `button.examples.tsx` and `toggle-button.examples.tsx` consumed by per-variant Storybook stories + a Playground each, add Buttons Overview / Button / Toggle Button MDX docs, regenerate `button.tokens.css` to drop the dead `--button-border-width`, `--button-border-radius`, and `--button-padding-y` vars, and tighten both test files (parameterized matrices, dropped redundant and class-name-only assertions, focused toggle-button tests on the toggle-specific behavior).

--- a/apps/storybook/stories/buttons/button.mdx
+++ b/apps/storybook/stories/buttons/button.mdx
@@ -1,0 +1,11 @@
+import { Meta, Markdown, Controls } from "@storybook/addon-docs/blocks";
+import readme from "../../../../packages/buttons/src/button/README.md?raw";
+import * as Stories from "./button.stories";
+
+<Meta of={Stories} />
+
+<Markdown>{readme}</Markdown>
+
+# Props
+
+<Controls of={Stories.Playground} />

--- a/apps/storybook/stories/buttons/button.stories.tsx
+++ b/apps/storybook/stories/buttons/button.stories.tsx
@@ -1,12 +1,9 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
-import { GlobeIcon, ExternalLinkIcon } from "@uiid/icons";
-import {
-  Stack,
-  Group,
-  Text,
-  Button,
-} from "@uiid/design-system";
+import { GlobeIcon } from "@uiid/icons";
+import { Button } from "@uiid/design-system";
+
+import * as Examples from "../../../../packages/buttons/src/button/button.examples";
 
 const meta = {
   title: "Buttons/Button",
@@ -16,13 +13,14 @@ const meta = {
     actions: { argTypesRegex: "^on.*" },
   },
   args: {
-    tooltip: "tooltip",
-    loading: false,
+    children: "Travel the world",
   },
   argTypes: {
+    children: { control: "text", table: { category: "Content" } },
+    tooltip: { control: "text", table: { category: "Content" } },
     disabled: { control: "boolean", table: { category: "Toggles" } },
     loading: { control: "boolean", table: { category: "Toggles" } },
-
+    fullwidth: { control: "boolean", table: { category: "Toggles" } },
     size: {
       control: "select",
       options: ["xsmall", "small", "medium", "large"],
@@ -38,7 +36,6 @@ const meta = {
       options: ["pill", "square", "circle"],
       table: { category: "Variants" },
     },
-
     onClick: { table: { category: "Events" } },
   },
 } satisfies Meta<typeof Button>;
@@ -46,81 +43,21 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-  name: "Button",
-  render: (args) => {
-    return (
-      <Stack gap={4}>
-        <Group gap={2}>
-          <Button {...args} shape="square">
-            <GlobeIcon />
-          </Button>
-          <Button {...args}>
-            <GlobeIcon />
-            travel the world
-          </Button>
-          <Button {...args} disabled>
-            <GlobeIcon />
-            travel the world
-          </Button>
-          <Button {...args} variant="subtle">
-            <GlobeIcon />
-            travel the world
-          </Button>
-          <Button {...args} variant="ghost">
-            <GlobeIcon />
-            travel the world
-          </Button>
-          <Button {...args} variant="inverted">
-            <GlobeIcon />
-            travel the world
-          </Button>
-        </Group>
-
-        <Group gap={2}>
-          <Button {...args} shape="circle">
-            <GlobeIcon />
-          </Button>
-          <Button {...args} shape="pill">
-            <GlobeIcon />
-            travel the world
-          </Button>
-          <Button {...args} disabled shape="pill">
-            <GlobeIcon />
-            travel the world
-          </Button>
-          <Button {...args} variant="subtle" shape="pill">
-            <GlobeIcon />
-            travel the world
-          </Button>
-          <Button {...args} variant="ghost" shape="pill">
-            <GlobeIcon />
-            travel the world
-          </Button>
-          <Button {...args} variant="inverted" shape="pill">
-            <GlobeIcon />
-            travel the world
-          </Button>
-        </Group>
-
-        <Button
-          {...args}
-          nativeButton={false}
-          render={<a href="https://www.google.com" target="_blank" />}
-          tooltip={
-            <Text size={-1}>
-              use{" "}
-              <Text weight="bold">
-                nativeButton
-              </Text>{" "}
-              when rendering a link
-            </Text>
-          }
-        >
-          google.com
-          <ExternalLinkIcon />
-        </Button>
-      </Stack>
-    );
-  },
+export const Playground: Story = {
+  render: (args) => (
+    <Button {...args}>
+      <GlobeIcon />
+      {args.children}
+    </Button>
+  ),
 };
+
+export const Variants: Story = { render: () => <Examples.Variants /> };
+export const Sizes: Story = { render: () => <Examples.Sizes /> };
+export const Shapes: Story = { render: () => <Examples.Shapes /> };
+export const WithIcon: Story = { render: () => <Examples.WithIcon /> };
+export const Disabled: Story = { render: () => <Examples.Disabled /> };
+export const Loading: Story = { render: () => <Examples.Loading /> };
+export const Fullwidth: Story = { render: () => <Examples.Fullwidth /> };
+export const WithTooltip: Story = { render: () => <Examples.WithTooltip /> };
+export const Polymorphic: Story = { render: () => <Examples.Polymorphic /> };

--- a/apps/storybook/stories/buttons/overview.mdx
+++ b/apps/storybook/stories/buttons/overview.mdx
@@ -1,0 +1,20 @@
+import { Meta } from "@storybook/addon-docs/blocks";
+
+<Meta title="Buttons/Overview" />
+
+# Buttons
+
+Action triggers. Variants change the surface, sizes match form-control heights, and shapes adapt the button for icon-only or pill-shaped affordances.
+
+## Which one do I reach for?
+
+- **[Button](?path=/docs/buttons-button--docs)** — the standard action. Renders as `<button>` by default; swap to `<a>`, `<span>`, or any element via the `render` prop (with `nativeButton={false}`).
+- **[Toggle Button](?path=/docs/buttons-toggle-button--docs)** — a Button with on/off state. Pair pressed/unpressed icons or text via the `icon`/`text` props.
+
+## Shared conventions
+
+- `size` mirrors form-control sizes (`xsmall`, `small`, `medium`, `large`) so buttons line up with `Input`, `Select`, etc.
+- `variant` only changes the surface: `subtle`, `ghost`, `inverted`. Default is the foreground-on-background filled style.
+- `shape` overrides the default rectangle: `pill` (rounded), `square` (1:1, no padding), `circle` (round, 1:1). Icon-only buttons typically pair `shape="square"` with `aria-label`.
+- `loading` swaps the content for a spinner while keeping the button's footprint stable.
+- `tooltip` wraps the trigger in a Tooltip — no need to compose it manually.

--- a/apps/storybook/stories/buttons/toggle-button.mdx
+++ b/apps/storybook/stories/buttons/toggle-button.mdx
@@ -1,0 +1,11 @@
+import { Meta, Markdown, Controls } from "@storybook/addon-docs/blocks";
+import readme from "../../../../packages/buttons/src/toggle-button/README.md?raw";
+import * as Stories from "./toggle-button.stories";
+
+<Meta of={Stories} />
+
+<Markdown>{readme}</Markdown>
+
+# Props
+
+<Controls of={Stories.Playground} />

--- a/apps/storybook/stories/buttons/toggle-button.stories.tsx
+++ b/apps/storybook/stories/buttons/toggle-button.stories.tsx
@@ -1,79 +1,55 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
-import { Heart, Sun, Moon } from "@uiid/icons";
-import { Stack, Group, ToggleButton } from "@uiid/design-system";
+import { Heart } from "@uiid/icons";
+import { ToggleButton } from "@uiid/design-system";
+
+import * as Examples from "../../../../packages/buttons/src/toggle-button/toggle-button.examples";
 
 const meta = {
   title: "Buttons/Toggle Button",
   component: ToggleButton,
   tags: ["beta"],
-  args: {},
+  parameters: {
+    actions: { argTypesRegex: "^on.*" },
+  },
+  args: {
+    children: "Favorite",
+  },
   argTypes: {
-    disabled: { control: "boolean" },
-    onClick: { action: "onClick" },
+    children: { control: "text", table: { category: "Content" } },
+    defaultPressed: { control: "boolean", table: { category: "State" } },
+    disabled: { control: "boolean", table: { category: "Toggles" } },
+    size: {
+      control: "select",
+      options: ["xsmall", "small", "medium", "large"],
+      table: { category: "Variants" },
+    },
+    variant: {
+      control: "select",
+      options: ["subtle", "ghost", "inverted"],
+      table: { category: "Variants" },
+    },
+    shape: {
+      control: "select",
+      options: ["pill", "square", "circle"],
+      table: { category: "Variants" },
+    },
   },
 } satisfies Meta<typeof ToggleButton>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-  name: "Toggle Button",
-  render: (args) => {
-    return (
-      <Stack gap={4}>
-        <Group gap={2} ay="center">
-          <ToggleButton
-            {...args}
-            icon={{ pressed: <Heart fill="red" />, unpressed: <Heart /> }}
-            shape="square"
-          />
-          <ToggleButton
-            {...args}
-            icon={{ pressed: <Heart fill="red" />, unpressed: <Heart /> }}
-          >
-            Favorite
-          </ToggleButton>
-          <ToggleButton
-            {...args}
-            icon={{ pressed: <Heart fill="red" />, unpressed: <Heart /> }}
-            text={{ pressed: "Favorited", unpressed: "Favorite" }}
-          />
-        </Group>
-
-        <Group gap={2} ay="center">
-          <ToggleButton
-            {...args}
-            variant="subtle"
-            icon={{
-              pressed: <Sun stroke="gold" />,
-              unpressed: <Moon stroke="aqua" />,
-            }}
-            shape="square"
-          />
-          <ToggleButton
-            {...args}
-            variant="subtle"
-            icon={{
-              pressed: <Sun stroke="gold" />,
-              unpressed: <Moon stroke="aqua" />,
-            }}
-          >
-            Toggle theme
-          </ToggleButton>
-          <ToggleButton
-            {...args}
-            variant="subtle"
-            text={{ pressed: "Dark Mode", unpressed: "Light Mode" }}
-            icon={{
-              pressed: <Sun stroke="gold" />,
-              unpressed: <Moon stroke="aqua" />,
-            }}
-          >
-            Light Mode
-          </ToggleButton>
-        </Group>
-      </Stack>
-    );
-  },
+export const Playground: Story = {
+  render: (args) => (
+    <ToggleButton
+      {...args}
+      icon={{ pressed: <Heart fill="red" />, unpressed: <Heart /> }}
+    />
+  ),
 };
+
+export const Pressed: Story = { render: () => <Examples.Pressed /> };
+export const DynamicIcon: Story = { render: () => <Examples.DynamicIcon /> };
+export const DynamicText: Story = { render: () => <Examples.DynamicText /> };
+export const IconAndText: Story = { render: () => <Examples.IconAndText /> };

--- a/packages/buttons/src/button/README.md
+++ b/packages/buttons/src/button/README.md
@@ -1,99 +1,16 @@
 # Button
 
-> Primary action button with multiple size and variant options
+> The standard action trigger. Filled by default; swap the surface with `variant`, the footprint with `shape`, and the element with `render`.
 
-## Quick Reference
+Use Button when you want to:
 
-```tsx
-import { Button } from "@uiid/buttons";
+- Trigger an action — `onClick` is forwarded straight to the underlying `<button>`
+- Match a form-control row with `size` (`xsmall`, `small`, `medium`, `large`)
+- Soften the surface with `variant`: `subtle` (low-contrast fill), `ghost` (transparent), `inverted` (background-on-foreground)
+- Reshape the footprint with `shape`: `pill` (rounded), `square` (1:1, no padding), `circle` (round, 1:1) — pair `shape="square"` with `aria-label` for icon-only buttons
+- Show a spinner with `loading` without the button changing size
+- Wrap the trigger in a Tooltip via `tooltip` — no manual composition
+- Stretch to the container with `fullwidth`
+- Render as a different element (`<a>`, `<span>`, etc.) via the `render` prop with `nativeButton={false}` — useful for link buttons; the link keeps its `href`, `target`, and `rel`
 
-// Basic usage
-<Button>Click me</Button>
-
-// With variants
-<Button variant="subtle" size="large" shape="pill">
-  Submit
-</Button>
-```
-
-## Examples
-
-### Basic
-
-```tsx
-<Button>Default button</Button>
-<Button disabled>Disabled</Button>
-```
-
-### Variants
-
-```tsx
-<Button variant="subtle">Subtle</Button>
-<Button variant="ghost">Ghost</Button>
-<Button variant="inverted">Inverted</Button>
-```
-
-### Sizes
-
-```tsx
-<Button size="xsmall">Extra Small</Button>
-<Button size="small">Small</Button>
-<Button size="medium">Medium</Button>
-<Button size="large">Large</Button>
-```
-
-### Shapes
-
-```tsx
-<Button shape="pill">Rounded pill</Button>
-<Button shape="square">■</Button>
-<Button shape="circle">●</Button>
-```
-
-### Loading State
-
-```tsx
-<Button loading>Submitting...</Button>
-```
-
-### As Link
-
-```tsx
-<Button nativeButton={false} render={<a href="/page" />}>
-  Navigate
-</Button>
-```
-
-## Props
-
-| Prop        | Type                                              | Default    | Description                           |
-| ----------- | ------------------------------------------------- | ---------- | ------------------------------------- |
-| `variant`   | `"subtle" \| "ghost" \| "inverted"`               | —          | Visual style variant                  |
-| `shape`     | `"pill" \| "square" \| "circle"`                  | —          | Button shape                          |
-| `size`      | `"xsmall" \| "small" \| "medium" \| "large"`      | `"medium"` | Size variant                          |
-| `fullwidth` | `boolean`                                         | —          | Expand to fill container width        |
-| `loading`   | `boolean`                                         | —          | Show loading spinner, hide content    |
-| `disabled`  | `boolean`                                         | —          | Disable the button                    |
-| `tooltip`   | `ReactNode`                                       | —          | Tooltip content                       |
-
-> Additional props are forwarded to the underlying Base UI Button.
-
-## Data Slots
-
-| Slot                       | Element             |
-| -------------------------- | ------------------- |
-| `button`                   | Root button element |
-| `button-content-container` | Content wrapper     |
-| `button-spinner`           | Loading spinner     |
-
-## Accessibility
-
-- Built on Base UI Button with proper ARIA attributes
-- Keyboard: `Enter` and `Space` trigger click
-- Supports `aria-label` for icon-only buttons
-- `disabled` state is properly announced
-
-## See Also
-
-- [ToggleButton](../toggle-button/README.md) - Button with toggle state
-- [Base UI Button](https://base-ui.com/react/components/button) - Underlying primitive
+Additional props are forwarded to the underlying Base UI Button.

--- a/packages/buttons/src/button/button.examples.tsx
+++ b/packages/buttons/src/button/button.examples.tsx
@@ -1,0 +1,113 @@
+import { ExternalLinkIcon, GlobeIcon } from "@uiid/icons";
+import { Group, Stack } from "@uiid/layout";
+import { Text } from "@uiid/typography";
+
+import { Button } from "./button";
+
+export const Default = () => <Button>Travel the world</Button>;
+
+export const Variants = () => (
+  <Group gap={2}>
+    <Button>Default</Button>
+    <Button variant="subtle">Subtle</Button>
+    <Button variant="ghost">Ghost</Button>
+    <Button variant="inverted">Inverted</Button>
+  </Group>
+);
+
+export const Sizes = () => (
+  <Group gap={2} ay="center">
+    <Button size="xsmall">xsmall</Button>
+    <Button size="small">small</Button>
+    <Button size="medium">medium</Button>
+    <Button size="large">large</Button>
+  </Group>
+);
+
+export const Shapes = () => (
+  <Group gap={2}>
+    <Button shape="square">
+      <GlobeIcon />
+    </Button>
+    <Button shape="circle">
+      <GlobeIcon />
+    </Button>
+    <Button shape="pill">
+      <GlobeIcon />
+      Pill
+    </Button>
+  </Group>
+);
+
+export const WithIcon = () => (
+  <Group gap={2}>
+    <Button>
+      <GlobeIcon />
+      Travel the world
+    </Button>
+    <Button variant="subtle">
+      Read more
+      <ExternalLinkIcon />
+    </Button>
+    <Button shape="square" aria-label="Globe">
+      <GlobeIcon />
+    </Button>
+  </Group>
+);
+
+export const Disabled = () => (
+  <Group gap={2}>
+    <Button disabled>Default</Button>
+    <Button disabled variant="subtle">
+      Subtle
+    </Button>
+    <Button disabled variant="ghost">
+      Ghost
+    </Button>
+    <Button disabled variant="inverted">
+      Inverted
+    </Button>
+  </Group>
+);
+
+export const Loading = () => (
+  <Group gap={2}>
+    <Button loading>Submitting</Button>
+    <Button loading variant="subtle">
+      Subtle
+    </Button>
+    <Button loading shape="square" aria-label="Loading" />
+  </Group>
+);
+
+export const Fullwidth = () => (
+  <Stack gap={2} maxw={320}>
+    <Button fullwidth>Default</Button>
+    <Button fullwidth variant="subtle">
+      Subtle
+    </Button>
+  </Stack>
+);
+
+export const WithTooltip = () => (
+  <Button tooltip="Opens in a new tab">
+    <GlobeIcon />
+    Hover me
+  </Button>
+);
+
+export const Polymorphic = () => (
+  <Button
+    nativeButton={false}
+    render={<a href="https://example.com" target="_blank" rel="noopener" />}
+    tooltip={
+      <Text size={-1}>
+        Set <Text weight="bold">nativeButton={`{false}`}</Text> when rendering
+        as a link
+      </Text>
+    }
+  >
+    example.com
+    <ExternalLinkIcon />
+  </Button>
+);

--- a/packages/buttons/src/button/button.test.tsx
+++ b/packages/buttons/src/button/button.test.tsx
@@ -4,354 +4,138 @@ import userEvent from "@testing-library/user-event";
 import { Button } from "./button";
 
 describe("Button", () => {
-  // ============================================
-  // RENDERING
-  // ============================================
-
-  it("renders a button element", () => {
+  it("renders children inside a button", () => {
     render(<Button>Click me</Button>);
-    expect(screen.getByRole("button")).toBeInTheDocument();
-  });
-
-  it("renders with data-slot attribute", () => {
-    render(<Button>Click me</Button>);
-    expect(screen.getByRole("button")).toHaveAttribute("data-slot", "button");
-  });
-
-  it("renders children content", () => {
-    render(<Button>Click me</Button>);
-    expect(screen.getByRole("button")).toHaveTextContent("Click me");
-  });
-
-  it("applies custom className", () => {
-    render(<Button className="custom-class">Click me</Button>);
-    expect(screen.getByRole("button")).toHaveClass("custom-class");
-  });
-
-  it("forwards additional props to root element", () => {
-    render(<Button data-testid="test-button">Click me</Button>);
-    expect(screen.getByTestId("test-button")).toBeInTheDocument();
-  });
-
-  // ============================================
-  // VARIANTS
-  // ============================================
-
-  it("renders with size variants", () => {
-    const { rerender } = render(<Button size="small">Small</Button>);
-    expect(screen.getByRole("button").className).toContain("size-small");
-
-    rerender(<Button size="medium">Medium</Button>);
-    expect(screen.getByRole("button").className).toContain("size-medium");
-
-    rerender(<Button size="large">Large</Button>);
-    expect(screen.getByRole("button").className).toContain("size-large");
-  });
-
-  it("renders with variant prop", () => {
-    const { rerender } = render(<Button variant="subtle">Subtle</Button>);
-    expect(screen.getByRole("button").className).toContain("variant-subtle");
-
-    rerender(<Button variant="ghost">Ghost</Button>);
-    expect(screen.getByRole("button").className).toContain("variant-ghost");
-
-    rerender(<Button variant="inverted">Inverted</Button>);
-    expect(screen.getByRole("button").className).toContain("variant-inverted");
-  });
-
-  it("renders with shape prop", () => {
-    const { rerender } = render(<Button shape="pill">Pill</Button>);
-    expect(screen.getByRole("button").className).toContain("shape-pill");
-
-    rerender(<Button shape="square">■</Button>);
-    expect(screen.getByRole("button").className).toContain("shape-square");
-
-    rerender(<Button shape="circle">●</Button>);
-    expect(screen.getByRole("button").className).toContain("shape-circle");
-  });
-
-  it("renders correctly with variant='ghost'", () => {
-    render(<Button variant="ghost">Ghost</Button>);
     const button = screen.getByRole("button");
-    expect(button.className).toContain("variant-ghost");
-    expect(button.className).not.toContain("variant-subtle");
-    expect(button.className).not.toContain("variant-inverted");
-    expect(button).toHaveTextContent("Ghost");
+    expect(button).toHaveTextContent("Click me");
+    expect(button).toHaveAttribute("data-slot", "button");
   });
 
-  it("renders correctly with shape='square'", () => {
-    render(<Button shape="square">■</Button>);
-    const button = screen.getByRole("button");
-    expect(button.className).toContain("shape-square");
-    expect(button.className).not.toContain("shape-pill");
-    expect(button.className).not.toContain("shape-circle");
-    expect(button).toHaveTextContent("■");
-  });
-
-  it("applies both variant='ghost' and shape='square' together", () => {
+  it("forwards className and arbitrary props", () => {
     render(
-      <Button variant="ghost" shape="square">
-        ■
+      <Button className="extra" data-testid="btn">
+        Hi
       </Button>,
     );
-    const button = screen.getByRole("button");
-    expect(button.className).toContain("variant-ghost");
-    expect(button.className).toContain("shape-square");
-    expect(button).toBeInTheDocument();
+    const button = screen.getByTestId("btn");
+    expect(button).toHaveClass("extra");
   });
 
-  it("applies transition-related base styles class", () => {
-    render(<Button>Styled</Button>);
-    const button = screen.getByRole("button");
-    expect(button.className).toContain("button");
+  it.each(["xsmall", "small", "medium", "large"] as const)(
+    "applies size=%s",
+    (size) => {
+      render(<Button size={size}>x</Button>);
+      expect(screen.getByRole("button").className).toContain(`size-${size}`);
+    },
+  );
 
-    const contentContainer = document.querySelector(
-      '[data-slot="button-content-container"]',
-    );
-    expect(contentContainer).toBeInTheDocument();
-  });
+  it.each(["subtle", "ghost", "inverted"] as const)(
+    "applies variant=%s",
+    (variant) => {
+      render(<Button variant={variant}>x</Button>);
+      expect(screen.getByRole("button").className).toContain(
+        `variant-${variant}`,
+      );
+    },
+  );
 
-  it("renders with all size variants including xsmall", () => {
-    const { rerender } = render(<Button size="xsmall">XSmall</Button>);
-    expect(screen.getByRole("button").className).toContain("size-xsmall");
+  it.each(["pill", "square", "circle"] as const)(
+    "applies shape=%s",
+    (shape) => {
+      render(<Button shape={shape}>x</Button>);
+      expect(screen.getByRole("button").className).toContain(`shape-${shape}`);
+    },
+  );
 
-    rerender(<Button size="small">Small</Button>);
-    expect(screen.getByRole("button").className).toContain("size-small");
-
-    rerender(<Button size="medium">Medium</Button>);
-    expect(screen.getByRole("button").className).toContain("size-medium");
-
-    rerender(<Button size="large">Large</Button>);
-    expect(screen.getByRole("button").className).toContain("size-large");
-  });
-
-  // ============================================
-  // INTERACTIONS
-  // ============================================
-
-  it("handles click events", async () => {
-    const handleClick = vi.fn();
+  it("fires onClick on click and keyboard", async () => {
+    const onClick = vi.fn();
     const user = userEvent.setup();
+    render(<Button onClick={onClick}>Click</Button>);
 
-    render(<Button onClick={handleClick}>Click me</Button>);
-    await user.click(screen.getByRole("button"));
-
-    expect(handleClick).toHaveBeenCalledTimes(1);
-  });
-
-  it("supports keyboard interaction with Enter", async () => {
-    const handleClick = vi.fn();
-    const user = userEvent.setup();
-
-    render(<Button onClick={handleClick}>Click me</Button>);
-    screen.getByRole("button").focus();
+    const button = screen.getByRole("button");
+    await user.click(button);
+    button.focus();
     await user.keyboard("{Enter}");
-
-    expect(handleClick).toHaveBeenCalled();
-  });
-
-  it("supports keyboard interaction with Space", async () => {
-    const handleClick = vi.fn();
-    const user = userEvent.setup();
-
-    render(<Button onClick={handleClick}>Click me</Button>);
-    screen.getByRole("button").focus();
     await user.keyboard(" ");
 
-    expect(handleClick).toHaveBeenCalled();
+    expect(onClick).toHaveBeenCalledTimes(3);
   });
 
-  // ============================================
-  // DISABLED STATE
-  // ============================================
-
-  it("can be disabled", () => {
-    render(<Button disabled>Disabled</Button>);
-    expect(screen.getByRole("button")).toBeDisabled();
-  });
-
-  it("does not trigger click when disabled", async () => {
-    const handleClick = vi.fn();
+  it("does not fire onClick when disabled", async () => {
+    const onClick = vi.fn();
     const user = userEvent.setup();
-
     render(
-      <Button disabled onClick={handleClick}>
+      <Button disabled onClick={onClick}>
         Disabled
       </Button>,
     );
-    await user.click(screen.getByRole("button"));
 
-    expect(handleClick).not.toHaveBeenCalled();
+    await user.click(screen.getByRole("button"));
+    expect(screen.getByRole("button")).toBeDisabled();
+    expect(onClick).not.toHaveBeenCalled();
   });
 
-  // ============================================
-  // LOADING STATE
-  // ============================================
-
-  it("shows loading state", () => {
-    render(<Button loading>Loading</Button>);
-    const contentContainer = document.querySelector(
+  it("hides content and shows spinner when loading", () => {
+    render(<Button loading>Submitting</Button>);
+    const content = document.querySelector(
       '[data-slot="button-content-container"]',
     );
-    expect(contentContainer).toHaveAttribute("data-loading", "true");
-    expect(contentContainer).toHaveAttribute("aria-hidden", "true");
-  });
-
-  it("shows spinner when loading", () => {
-    render(<Button loading>Loading</Button>);
     const spinner = document.querySelector('[data-slot="button-spinner"]');
+
+    expect(content).toHaveAttribute("data-loading", "true");
+    expect(content).toHaveAttribute("aria-hidden", "true");
     expect(spinner).toHaveAttribute("data-loading", "true");
   });
 
-  it("hides content when loading", () => {
-    render(<Button loading>Loading</Button>);
-    const contentContainer = document.querySelector(
-      '[data-slot="button-content-container"]',
-    );
-    expect(contentContainer).toHaveAttribute("aria-hidden", "true");
-  });
-
-  // ============================================
-  // ACCESSIBILITY
-  // ============================================
-
-  it("has accessible name from children", () => {
-    render(<Button>Submit form</Button>);
-    expect(screen.getByRole("button")).toHaveAccessibleName("Submit form");
-  });
-
   it("supports aria-label for icon-only buttons", () => {
-    render(<Button aria-label="Close dialog">✕</Button>);
-    expect(screen.getByRole("button")).toHaveAccessibleName("Close dialog");
+    render(<Button aria-label="Close">✕</Button>);
+    expect(screen.getByRole("button")).toHaveAccessibleName("Close");
   });
 
-  it("supports aria-describedby", () => {
-    render(
-      <>
-        <Button aria-describedby="help-text">Submit</Button>
-        <span id="help-text">This will submit the form</span>
-      </>,
-    );
-    expect(screen.getByRole("button")).toHaveAttribute(
-      "aria-describedby",
-      "help-text",
-    );
-  });
-
-  // ============================================
-  // TYPE ATTRIBUTE
-  // ============================================
-
-  it("defaults to type button", () => {
-    render(<Button>Click me</Button>);
+  it("defaults to type=button and accepts submit/reset", () => {
+    const { rerender } = render(<Button>x</Button>);
     expect(screen.getByRole("button")).toHaveAttribute("type", "button");
-  });
 
-  it("can be set to type submit", () => {
-    render(<Button type="submit">Submit</Button>);
+    rerender(<Button type="submit">x</Button>);
     expect(screen.getByRole("button")).toHaveAttribute("type", "submit");
-  });
 
-  it("can be set to type reset", () => {
-    render(<Button type="reset">Reset</Button>);
+    rerender(<Button type="reset">x</Button>);
     expect(screen.getByRole("button")).toHaveAttribute("type", "reset");
   });
 
-  // ============================================
-  // BASE UI API
-  // ============================================
-
-  it("renders as anchor element when nativeButton is false with render prop", () => {
-    render(
-      <Button nativeButton={false} render={<a href="https://example.com" />}>
-        Visit site
-      </Button>,
-    );
-
-    // Base UI adds role="button" to maintain button semantics
-    const button = screen.getByRole("button");
-    expect(button.tagName).toBe("A");
-    expect(button).toHaveAttribute("href", "https://example.com");
-    expect(button).toHaveTextContent("Visit site");
-  });
-
-  it("preserves button styling when rendered as anchor", () => {
-    render(
-      <Button
-        nativeButton={false}
-        render={<a href="https://example.com" />}
-        size="large"
-        variant="subtle"
-      >
-        Visit site
-      </Button>,
-    );
-
-    const button = screen.getByRole("button");
-    expect(button.tagName).toBe("A");
-    expect(button.className).toContain("size-large");
-    expect(button.className).toContain("variant-subtle");
-  });
-
-  it("preserves anchor attributes when using render prop", () => {
+  it("renders as an anchor via the render prop and preserves href/target/rel", () => {
     render(
       <Button
         nativeButton={false}
         render={<a href="https://example.com" target="_blank" rel="noopener" />}
+        size="large"
+        variant="subtle"
       >
-        External link
+        Visit
       </Button>,
     );
 
-    const button = screen.getByRole("button");
-    expect(button).toHaveAttribute("href", "https://example.com");
-    expect(button).toHaveAttribute("target", "_blank");
-    expect(button).toHaveAttribute("rel", "noopener");
+    const link = screen.getByRole("button");
+    expect(link.tagName).toBe("A");
+    expect(link).toHaveAttribute("href", "https://example.com");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener");
+    expect(link).toHaveAttribute("data-slot", "button");
+    expect(link.className).toContain("size-large");
+    expect(link.className).toContain("variant-subtle");
   });
 
-  it("renders as custom element with render prop", () => {
+  it("triggers onClick from Enter on a polymorphic anchor", async () => {
+    const onClick = vi.fn();
+    const user = userEvent.setup();
     render(
-      <Button nativeButton={false} render={<span />}>
-        Span button
-      </Button>,
-    );
-
-    // Base UI still applies role="button" to custom elements
-    const button = screen.getByRole("button");
-    expect(button.tagName).toBe("SPAN");
-    expect(button).toHaveTextContent("Span button");
-  });
-
-  it("applies data-slot to custom rendered element", () => {
-    render(
-      <Button nativeButton={false} render={<a href="#" />}>
+      <Button nativeButton={false} render={<a href="#" />} onClick={onClick}>
         Link
       </Button>,
     );
 
-    const button = screen.getByRole("button");
-    expect(button.tagName).toBe("A");
-    expect(button).toHaveAttribute("data-slot", "button");
-  });
-
-  it("supports keyboard interaction on anchor rendered as button", async () => {
-    const handleClick = vi.fn();
-    const user = userEvent.setup();
-
-    render(
-      <Button
-        nativeButton={false}
-        render={<a href="#" />}
-        onClick={handleClick}
-      >
-        Link button
-      </Button>,
-    );
-
-    const button = screen.getByRole("button");
-    button.focus();
+    screen.getByRole("button").focus();
     await user.keyboard("{Enter}");
-
-    expect(handleClick).toHaveBeenCalled();
+    expect(onClick).toHaveBeenCalled();
   });
 });

--- a/packages/buttons/src/toggle-button/README.md
+++ b/packages/buttons/src/toggle-button/README.md
@@ -1,93 +1,12 @@
 # ToggleButton
 
-> Toggle button with pressed/unpressed states and optional dynamic icon/text
+> A Button with an on/off state. Pair `pressed`/`unpressed` icons or text via the `icon` and `text` props.
 
-## Quick Reference
+Use ToggleButton when you want to:
 
-```tsx
-import { ToggleButton } from "@uiid/buttons";
+- Track a binary pressed state — controlled via `pressed` + `onPressedChange`, or uncontrolled via `defaultPressed`
+- Swap icons by pressed state with `icon={{ pressed, unpressed }}` — common for favorite/like, follow, theme toggles
+- Swap labels by pressed state with `text={{ pressed, unpressed }}` — overrides `children` while the toggle is in that state; if `text` is omitted, `children` renders in both states
+- Inherit everything from [Button](../button/README.md): `variant`, `size`, `shape`, `fullwidth`, `loading`, `tooltip`, `render`
 
-// Basic usage
-<ToggleButton>Toggle me</ToggleButton>
-
-// With dynamic content
-<ToggleButton
-  text={{ pressed: "On", unpressed: "Off" }}
-  icon={{ pressed: <CheckIcon />, unpressed: <XIcon /> }}
-/>
-```
-
-## Examples
-
-### Basic
-
-```tsx
-<ToggleButton>Toggle</ToggleButton>
-<ToggleButton disabled>Disabled</ToggleButton>
-```
-
-### Dynamic Text
-
-```tsx
-<ToggleButton text={{ pressed: "Enabled", unpressed: "Disabled" }}>
-  Default text
-</ToggleButton>
-```
-
-### Dynamic Icons
-
-```tsx
-<ToggleButton
-  icon={{
-    pressed: <Heart fill="red" />,
-    unpressed: <Heart />,
-  }}
-  shape="square"
-/>
-```
-
-### Controlled
-
-```tsx
-const [pressed, setPressed] = useState(false);
-
-<ToggleButton pressed={pressed} onPressedChange={setPressed}>
-  {pressed ? "Active" : "Inactive"}
-</ToggleButton>;
-```
-
-## Props
-
-| Prop             | Type                                              | Default    | Description |
-| ---------------- | ------------------------------------------------- | ---------- | ----------- |
-| `defaultPressed` | `boolean`                                         | —          | —           |
-| `disabled`       | `boolean`                                         | —          | —           |
-| `fullwidth`      | `boolean`                                         | —          | —           |
-| `icon`           | `object`                                          | —          | —           |
-| `loading`        | `boolean`                                         | —          | —           |
-| `pressed`        | `boolean`                                         | —          | —           |
-| `shape`          | `"pill" \| "square" \| "circle"`                  | —          | —           |
-| `size`           | `"xsmall" \| "small" \| "medium" \| "large"`      | `"medium"` | —           |
-| `text`           | `object`                                          | —          | —           |
-| `tone`           | `"positive" \| "critical" \| "warning" \| "info"` | —          | —           |
-| `tooltip`        | `ReactNode`                                       | —          | —           |
-| `variant`        | `"subtle" \| "ghost" \| "inverted"`               | —          | —           |
-
-> Inherits all props from [Button](../button/README.md) including `variant`, `size`, `tone`, etc.
-
-## Data Slots
-
-| Slot     | Element                                     |
-| -------- | ------------------------------------------- |
-| `button` | Root button element (inherited from Button) |
-
-## Accessibility
-
-- Built on Base UI Toggle with `aria-pressed` attribute
-- Keyboard: `Enter` and `Space` toggle state
-- Screen readers announce pressed/unpressed state
-
-## See Also
-
-- [Button](../button/README.md) - Base button component
-- [Base UI Toggle](https://base-ui.com/react/components/toggle) - Underlying primitive
+The underlying primitive is Base UI Toggle, so `aria-pressed` is managed automatically and `Enter`/`Space` toggle the state.

--- a/packages/buttons/src/toggle-button/toggle-button.examples.tsx
+++ b/packages/buttons/src/toggle-button/toggle-button.examples.tsx
@@ -1,0 +1,56 @@
+import { Heart, Moon, Sun } from "@uiid/icons";
+import { Group, Stack } from "@uiid/layout";
+
+import { ToggleButton } from "./toggle-button";
+
+export const Default = () => <ToggleButton>Favorite</ToggleButton>;
+
+export const Pressed = () => (
+  <Group gap={2}>
+    <ToggleButton>Unpressed</ToggleButton>
+    <ToggleButton defaultPressed>Pressed</ToggleButton>
+    <ToggleButton disabled>Disabled</ToggleButton>
+    <ToggleButton disabled defaultPressed>
+      Disabled pressed
+    </ToggleButton>
+  </Group>
+);
+
+export const DynamicIcon = () => (
+  <Group gap={2}>
+    <ToggleButton
+      shape="square"
+      aria-label="Favorite"
+      icon={{ pressed: <Heart fill="red" />, unpressed: <Heart /> }}
+    />
+    <ToggleButton
+      icon={{ pressed: <Heart fill="red" />, unpressed: <Heart /> }}
+    >
+      Favorite
+    </ToggleButton>
+  </Group>
+);
+
+export const DynamicText = () => (
+  <Group gap={2}>
+    <ToggleButton
+      variant="subtle"
+      text={{ pressed: "Following", unpressed: "Follow" }}
+    />
+    <ToggleButton text={{ pressed: "Saved", unpressed: "Save" }} />
+  </Group>
+);
+
+export const IconAndText = () => (
+  <Stack gap={2} maxw={320}>
+    <ToggleButton
+      variant="subtle"
+      icon={{ pressed: <Sun stroke="gold" />, unpressed: <Moon /> }}
+      text={{ pressed: "Light mode", unpressed: "Dark mode" }}
+    />
+    <ToggleButton
+      icon={{ pressed: <Heart fill="red" />, unpressed: <Heart /> }}
+      text={{ pressed: "Liked", unpressed: "Like" }}
+    />
+  </Stack>
+);

--- a/packages/buttons/src/toggle-button/toggle-button.test.tsx
+++ b/packages/buttons/src/toggle-button/toggle-button.test.tsx
@@ -5,240 +5,113 @@ import userEvent from "@testing-library/user-event";
 import { ToggleButton } from "./toggle-button";
 
 describe("ToggleButton", () => {
-  // ============================================
-  // RENDERING
-  // ============================================
-
-  it("renders a button element", () => {
+  it("renders an unpressed button by default", () => {
     render(<ToggleButton>Toggle</ToggleButton>);
-    expect(screen.getByRole("button")).toBeInTheDocument();
+    const button = screen.getByRole("button");
+    expect(button).toHaveTextContent("Toggle");
+    expect(button).toHaveAttribute("aria-pressed", "false");
+    expect(button).toHaveAttribute("data-slot", "button");
   });
 
-  it("renders with data-slot attribute from underlying Button", () => {
-    render(<ToggleButton>Toggle</ToggleButton>);
-    expect(screen.getByRole("button")).toHaveAttribute("data-slot", "button");
-  });
-
-  it("renders children content", () => {
-    render(<ToggleButton>Toggle me</ToggleButton>);
-    expect(screen.getByRole("button")).toHaveTextContent("Toggle me");
-  });
-
-  it("applies custom className", () => {
-    render(<ToggleButton className="custom-class">Toggle</ToggleButton>);
-    expect(screen.getByRole("button")).toHaveClass("custom-class");
-  });
-
-  // ============================================
-  // TOGGLE STATE
-  // ============================================
-
-  it("starts in unpressed state by default", () => {
-    render(<ToggleButton>Toggle</ToggleButton>);
-    expect(screen.getByRole("button")).toHaveAttribute("aria-pressed", "false");
-  });
-
-  it("can be toggled by clicking", async () => {
+  it("toggles aria-pressed on click and on Enter/Space", async () => {
     const user = userEvent.setup();
     render(<ToggleButton>Toggle</ToggleButton>);
-
     const button = screen.getByRole("button");
-    expect(button).toHaveAttribute("aria-pressed", "false");
 
     await user.click(button);
     expect(button).toHaveAttribute("aria-pressed", "true");
 
-    await user.click(button);
+    button.focus();
+    await user.keyboard("{Enter}");
     expect(button).toHaveAttribute("aria-pressed", "false");
+
+    await user.keyboard(" ");
+    expect(button).toHaveAttribute("aria-pressed", "true");
   });
 
-  it("supports controlled pressed state", async () => {
-    const handleChange = vi.fn();
+  it("respects defaultPressed for uncontrolled usage", () => {
+    render(<ToggleButton defaultPressed>Toggle</ToggleButton>);
+    expect(screen.getByRole("button")).toHaveAttribute("aria-pressed", "true");
+  });
 
-    const ControlledToggle = () => {
+  it("supports controlled pressed state via onPressedChange", async () => {
+    const onPressedChange = vi.fn();
+    const Controlled = () => {
       const [pressed, setPressed] = useState(false);
       return (
         <ToggleButton
           pressed={pressed}
-          onPressedChange={(value) => {
-            setPressed(value);
-            handleChange(value);
+          onPressedChange={(v) => {
+            setPressed(v);
+            onPressedChange(v);
           }}
         >
           Toggle
         </ToggleButton>
       );
     };
-
     const user = userEvent.setup();
-    render(<ControlledToggle />);
-
+    render(<Controlled />);
     const button = screen.getByRole("button");
-    expect(button).toHaveAttribute("aria-pressed", "false");
 
     await user.click(button);
-    expect(handleChange).toHaveBeenCalledWith(true);
+    expect(onPressedChange).toHaveBeenCalledWith(true);
     expect(button).toHaveAttribute("aria-pressed", "true");
 
     await user.click(button);
-    expect(handleChange).toHaveBeenCalledWith(false);
+    expect(onPressedChange).toHaveBeenCalledWith(false);
     expect(button).toHaveAttribute("aria-pressed", "false");
   });
 
-  it("supports defaultPressed for uncontrolled usage", () => {
-    render(<ToggleButton defaultPressed>Toggle</ToggleButton>);
-    expect(screen.getByRole("button")).toHaveAttribute("aria-pressed", "true");
-  });
-
-  // ============================================
-  // DYNAMIC TEXT
-  // ============================================
-
-  it("shows unpressed text when not pressed", () => {
-    render(
-      <ToggleButton text={{ pressed: "On", unpressed: "Off" }}>
-        Default
-      </ToggleButton>,
-    );
-    expect(screen.getByRole("button")).toHaveTextContent("Off");
-  });
-
-  it("shows pressed text when pressed", async () => {
+  it("swaps text by pressed state and falls back to children when text is absent", async () => {
     const user = userEvent.setup();
-    render(
+    const { rerender } = render(
       <ToggleButton text={{ pressed: "On", unpressed: "Off" }}>
         Default
       </ToggleButton>,
     );
-
     const button = screen.getByRole("button");
+    expect(button).toHaveTextContent("Off");
+
     await user.click(button);
-
     expect(button).toHaveTextContent("On");
-  });
 
-  it("falls back to children when text prop not provided", () => {
-    render(<ToggleButton>Fallback</ToggleButton>);
+    rerender(<ToggleButton>Fallback</ToggleButton>);
     expect(screen.getByRole("button")).toHaveTextContent("Fallback");
   });
 
-  // ============================================
-  // DYNAMIC ICONS
-  // ============================================
-
-  it("shows unpressed icon when not pressed", () => {
-    render(
-      <ToggleButton
-        icon={{
-          pressed: <span data-testid="icon-on">🔔</span>,
-          unpressed: <span data-testid="icon-off">🔕</span>,
-        }}
-      >
-        Notifications
-      </ToggleButton>,
-    );
-
-    expect(screen.getByTestId("icon-off")).toBeInTheDocument();
-    expect(screen.queryByTestId("icon-on")).not.toBeInTheDocument();
-  });
-
-  it("shows pressed icon when pressed", async () => {
+  it("swaps icon by pressed state", async () => {
     const user = userEvent.setup();
     render(
       <ToggleButton
         icon={{
-          pressed: <span data-testid="icon-on">🔔</span>,
-          unpressed: <span data-testid="icon-off">🔕</span>,
+          pressed: <span data-testid="on">on</span>,
+          unpressed: <span data-testid="off">off</span>,
         }}
       >
         Notifications
       </ToggleButton>,
     );
+
+    expect(screen.getByTestId("off")).toBeInTheDocument();
+    expect(screen.queryByTestId("on")).not.toBeInTheDocument();
 
     await user.click(screen.getByRole("button"));
-
-    expect(screen.getByTestId("icon-on")).toBeInTheDocument();
-    expect(screen.queryByTestId("icon-off")).not.toBeInTheDocument();
-  });
-
-  // ============================================
-  // KEYBOARD INTERACTION
-  // ============================================
-
-  it("can be toggled with Enter key", async () => {
-    const user = userEvent.setup();
-    render(<ToggleButton>Toggle</ToggleButton>);
-
-    const button = screen.getByRole("button");
-    button.focus();
-    await user.keyboard("{Enter}");
-
-    expect(button).toHaveAttribute("aria-pressed", "true");
-  });
-
-  it("can be toggled with Space key", async () => {
-    const user = userEvent.setup();
-    render(<ToggleButton>Toggle</ToggleButton>);
-
-    const button = screen.getByRole("button");
-    button.focus();
-    await user.keyboard(" ");
-
-    expect(button).toHaveAttribute("aria-pressed", "true");
-  });
-
-  // ============================================
-  // DISABLED STATE
-  // ============================================
-
-  it("can be disabled", () => {
-    render(<ToggleButton disabled>Toggle</ToggleButton>);
-    expect(screen.getByRole("button")).toBeDisabled();
+    expect(screen.getByTestId("on")).toBeInTheDocument();
+    expect(screen.queryByTestId("off")).not.toBeInTheDocument();
   });
 
   it("does not toggle when disabled", async () => {
     const user = userEvent.setup();
     render(<ToggleButton disabled>Toggle</ToggleButton>);
-
     const button = screen.getByRole("button");
-    expect(button).toHaveAttribute("aria-pressed", "false");
 
     await user.click(button);
+    expect(button).toBeDisabled();
     expect(button).toHaveAttribute("aria-pressed", "false");
   });
 
-  // ============================================
-  // BUTTON VARIANTS (inherited from Button)
-  // ============================================
-
-  it("supports size variants", () => {
-    const { rerender } = render(<ToggleButton size="small">Toggle</ToggleButton>);
-    expect(screen.getByRole("button").className).toContain("size-small");
-
-    rerender(<ToggleButton size="large">Toggle</ToggleButton>);
-    expect(screen.getByRole("button").className).toContain("size-large");
-  });
-
-  it("supports ghost variant", () => {
-    render(<ToggleButton variant="ghost">Toggle</ToggleButton>);
-    expect(screen.getByRole("button").className).toContain("variant-ghost");
-  });
-
-  it("supports pill shape", () => {
-    render(<ToggleButton shape="pill">Toggle</ToggleButton>);
-    expect(screen.getByRole("button").className).toContain("shape-pill");
-  });
-
-  // ============================================
-  // ACCESSIBILITY
-  // ============================================
-
-  it("has aria-pressed attribute", () => {
-    render(<ToggleButton>Toggle</ToggleButton>);
-    expect(screen.getByRole("button")).toHaveAttribute("aria-pressed");
-  });
-
-  it("supports aria-label", () => {
+  it("supports aria-label for icon-only triggers", () => {
     render(<ToggleButton aria-label="Toggle notifications">🔔</ToggleButton>);
     expect(screen.getByRole("button")).toHaveAccessibleName(
       "Toggle notifications",

--- a/packages/tokens/src/json/component/button.tokens.json
+++ b/packages/tokens/src/json/component/button.tokens.json
@@ -17,15 +17,9 @@
       }
     },
     "fg": { "$value": "{shade.background}", "$type": "color" },
-    "border-width": { "$value": "2px", "$type": "dimension" },
     "border-color": { "$value": "{button.bg}", "$type": "color" },
-    "border-radius": {
-      "$value": "{globals.border.radius}",
-      "$type": "dimension"
-    },
     "font-weight": { "$value": 600, "$type": "fontWeight" },
     "padding-x": { "$value": "{forms.padding.x}", "$type": "dimension" },
-    "padding-y": { "$value": "{forms.padding.y}", "$type": "dimension" },
     "size": {
       "xs": {
         "font-size": {


### PR DESCRIPTION
## Summary

- Split `Button` and `ToggleButton` stories into focused per-variant exports (Variants/Sizes/Shapes/WithIcon/Disabled/Loading/Fullwidth/WithTooltip/Polymorphic for Button; Pressed/DynamicIcon/DynamicText/IconAndText for ToggleButton) consuming new `*.examples.tsx` files, plus a `Playground` story wired to Controls — mirrors the cards cleanup pattern.
- Added MDX docs: `overview.mdx`, `button.mdx`, `toggle-button.mdx`.
- Rewrote both READMEs in short-form voice; dropped the prop tables (rot-prone) and the stale `tone` prop reference in toggle-button.
- Pruned dead tokens from `button.tokens.json`: `--button-border-width`, `--button-border-radius`, `--button-padding-y` — `button.module.css` was using `var(--globals-*)` equivalents.
- Tightened tests: `button.test.tsx` ~33 → 19, `toggle-button.test.tsx` 22 → 8. Replaced repeated rerenders with `it.each` matrices, dropped class-name-only assertions and the sentinel "applies transition base styles" test.

## Breaking Changes

None.

## Checklist

- [ ] Button stories (Playground, Variants, Sizes, Shapes, WithIcon, Disabled, Loading, Fullwidth, WithTooltip, Polymorphic) render in Storybook.
- [ ] ToggleButton stories (Playground, Pressed, DynamicIcon, DynamicText, IconAndText) render in Storybook.
- [ ] Buttons Overview MDX, Button MDX, and Toggle Button MDX pages display the rewritten READMEs and the Playground props table.
- [ ] No production code references the removed tokens (`--button-border-width`, `--button-border-radius`, `--button-padding-y`).
- [ ] `pnpm test:run` passes (845 tests).
- [ ] `pnpm build --filter=@uiid/buttons` succeeds.