### PR TITLE
feat(ui): support category prop on top-level List

### DIFF
--- a/.changeset/anchor-default-color.md
+++ b/.changeset/anchor-default-color.md
@@ -1,0 +1,5 @@
+---
+"@uiid/tokens": patch
+---
+
+Remove the hardcoded `--theme-primary` color from the global anchor style so links inherit their surrounding text color by default.

--- a/.changeset/list-top-level-category.md
+++ b/.changeset/list-top-level-category.md
@@ -1,0 +1,5 @@
+---
+"@uiid/lists": patch
+---
+
+Add a top-level `category` (and `icon`) prop to `List` so a group header can be rendered above the whole list. Extract the shared `ListGroupHeader` subcomponent and fix list indentation by moving the padding reset into CSS (the previous inline `p={0}` overrode the category/marker indent rules).

--- a/apps/blocks/components/tree-navigator.tsx
+++ b/apps/blocks/components/tree-navigator.tsx
@@ -87,7 +87,7 @@ export const TreeNavigator = () => {
       style={{ overflowY: "auto" }}
       br={1}
     >
-      <List line items={items} />
+      <List items={items} />
     </Stack>
   );
 };

--- a/apps/docs/components/header.tsx
+++ b/apps/docs/components/header.tsx
@@ -9,12 +9,7 @@ import {
 import { SearchIcon, SunIcon, MoonIcon, MonitorIcon } from "@uiid/icons";
 
 import { SHELL_SPACING, SHELL_BORDER_WIDTH } from "@/constants";
-
-const BREADCRUMBS_ITEMS = [
-  { label: "Home", value: "/" },
-  { label: "About", value: "/about" },
-  { label: "Contact", value: "/contact" },
-];
+import { SITEMAP } from "@/sitemap";
 
 export function Header() {
   return (
@@ -59,9 +54,7 @@ const HeaderGroup = ({ children }: React.PropsWithChildren) => {
 HeaderGroup.displayName = "HeaderGroup";
 
 const HeaderBreadcrumbs = () => {
-  return (
-    <Breadcrumbs data-slot="header-breadcrumbs" items={BREADCRUMBS_ITEMS} />
-  );
+  return <Breadcrumbs data-slot="header-breadcrumbs" items={SITEMAP} />;
 };
 HeaderBreadcrumbs.displayName = "HeaderBreadcrumbs";
 

--- a/apps/docs/components/sidebar.tsx
+++ b/apps/docs/components/sidebar.tsx
@@ -1,12 +1,20 @@
-import { Stack, Text } from "@uiid/design-system";
+import Link from "next/link";
+import { List, ListItem, Stack, Text } from "@uiid/design-system";
 
-import { SIDEBAR_WIDTH, SHELL_SPACING, SHELL_BORDER_WIDTH } from "@/constants";
+import {
+  SIDEBAR_WIDTH,
+  SIDEBAR_SPACING,
+  SHELL_BORDER_WIDTH,
+  SIDEBAR_LIST_ITEM_SPACING,
+} from "@/constants";
+import { SITEMAP, type SitemapItem } from "@/sitemap";
 
 export function Sidebar() {
   return (
     <SidebarContainer>
       <SidebarScrollContainer>
         <SidebarHeader>uiid docs</SidebarHeader>
+        <SidebarList items={SITEMAP} category="Navigation" />
       </SidebarScrollContainer>
     </SidebarContainer>
   );
@@ -33,6 +41,8 @@ const SidebarScrollContainer = ({ children }: React.PropsWithChildren) => {
       data-slot="sidebar-scroll-container"
       className="sticky top-0 overflow-y-auto h-screen"
       ax="stretch"
+      gap={SIDEBAR_SPACING}
+      p={SIDEBAR_SPACING}
     >
       {children}
     </Stack>
@@ -42,9 +52,31 @@ SidebarScrollContainer.displayName = "SidebarScrollContainer";
 
 const SidebarHeader = ({ children }: React.PropsWithChildren) => {
   return (
-    <Text data-slot="sidebar-header" weight="bold" p={SHELL_SPACING} size={3}>
+    <Text data-slot="sidebar-header" weight="bold" size={3}>
       {children}
     </Text>
   );
 };
 SidebarHeader.displayName = "SidebarHeader";
+
+type SidebarListProps = {
+  items: SitemapItem[];
+  category?: string;
+};
+
+const SidebarList = ({ items, category }: SidebarListProps) => {
+  return (
+    <List
+      data-slot="sidebar-list"
+      gap={SIDEBAR_LIST_ITEM_SPACING}
+      category={category}
+    >
+      {items.map((item) => (
+        <ListItem key={item.value}>
+          <Text render={<Link href={item.value} />}>{item.label}</Text>
+        </ListItem>
+      ))}
+    </List>
+  );
+};
+SidebarList.displayName = "SidebarList";

--- a/apps/docs/components/sidebar.tsx
+++ b/apps/docs/components/sidebar.tsx
@@ -14,7 +14,8 @@ export function Sidebar() {
     <SidebarContainer>
       <SidebarScrollContainer>
         <SidebarHeader>uiid docs</SidebarHeader>
-        <SidebarList items={SITEMAP} category="Navigation" />
+        <SidebarList items={SITEMAP} />
+        <SidebarList items={SITEMAP} category="Components" />
       </SidebarScrollContainer>
     </SidebarContainer>
   );

--- a/apps/docs/constants.ts
+++ b/apps/docs/constants.ts
@@ -2,8 +2,11 @@ export const SITE_TITLE = "uiid docs";
 export const SITE_DESCRIPTION =
   "Documentation for UIID - A modern, modular component library built with TypeScript, Vite, React, and CSS Modules.";
 
-export const SIDEBAR_WIDTH = 280;
-export const CONTENT_MAX_WIDTH = 960;
-
 export const SHELL_SPACING = 4;
 export const SHELL_BORDER_WIDTH = 1;
+
+export const SIDEBAR_WIDTH = 280;
+export const SIDEBAR_SPACING = SHELL_SPACING * 2;
+export const SIDEBAR_LIST_ITEM_SPACING = 1;
+
+export const CONTENT_MAX_WIDTH = 960;

--- a/apps/docs/sitemap.ts
+++ b/apps/docs/sitemap.ts
@@ -1,0 +1,10 @@
+export type SitemapItem = {
+  label: string;
+  value: string;
+};
+
+export const SITEMAP: SitemapItem[] = [
+  { label: "Home", value: "/" },
+  { label: "About", value: "/about" },
+  { label: "Contact", value: "/contact" },
+];

--- a/packages/lists/src/index.ts
+++ b/packages/lists/src/index.ts
@@ -1,3 +1,3 @@
 export * from "./list/list";
 export * from "./list/list.types";
-export { ListItem, ListGroup } from "./list/subcomponents";
+export { ListItem, ListGroup, ListGroupHeader } from "./list/subcomponents";

--- a/packages/lists/src/list/README.md
+++ b/packages/lists/src/list/README.md
@@ -7,7 +7,6 @@ Use List when you want to:
 - Render an array of items with `items` — each entry is a `ListItem` (`{ label, description, icon }`) or a `ListGroup` (`{ category, icon, items }`) for nesting
 - Compose by hand instead — pass `<ListItem>` and `<ListGroup>` as children
 - Pick a bullet style with `marker`: `"none"` (default, unstyled), `"disc"` / `"square"` (renders `<ul>`), or `"decimal"` (renders `<ol>`)
-- Add a vertical guide on nested group panels with `line` — useful for tree-style navigation
 - Apply shared overrides to every rendered item or group via `ItemProps` and `GroupProps` on the wrapper
 
 Both shapes coexist: `items` is the fast path for data, JSX children is the escape hatch for custom layouts. They render the same output.

--- a/packages/lists/src/list/list.examples.tsx
+++ b/packages/lists/src/list/list.examples.tsx
@@ -1,12 +1,4 @@
-import {
-  Bug,
-  Code,
-  FileText,
-  Folder,
-  Hammer,
-  Image,
-  Star,
-} from "@uiid/icons";
+import { Bug, Code, FileText, Folder, Hammer, Image, Star } from "@uiid/icons";
 import { Group, Stack } from "@uiid/layout";
 import { Text } from "@uiid/typography";
 
@@ -15,11 +7,7 @@ import { ListGroup, ListItem } from "./subcomponents";
 
 export const Default = () => (
   <List
-    items={[
-      { label: "Item 1" },
-      { label: "Item 2" },
-      { label: "Item 3" },
-    ]}
+    items={[{ label: "Item 1" }, { label: "Item 2" }, { label: "Item 3" }]}
   />
 );
 
@@ -51,9 +39,16 @@ export const WithDescriptions = () => (
   />
 );
 
+export const WithCategory = () => (
+  <List
+    category="Navigation"
+    icon={Folder}
+    items={[{ label: "Home" }, { label: "About" }, { label: "Contact" }]}
+  />
+);
+
 export const NestedGroups = () => (
   <List
-    line
     items={[
       {
         category: "Source",
@@ -83,27 +78,31 @@ export const NestedGroups = () => (
 );
 
 export const Markers = () => {
-  const items = [
-    { label: "First" },
-    { label: "Second" },
-    { label: "Third" },
-  ];
+  const items = [{ label: "First" }, { label: "Second" }, { label: "Third" }];
   return (
     <Group gap={8} ay="start">
       <Stack gap={2}>
-        <Text size={0} weight="bold">none</Text>
+        <Text size={0} weight="bold">
+          none
+        </Text>
         <List marker="none" items={items} />
       </Stack>
       <Stack gap={2}>
-        <Text size={0} weight="bold">disc</Text>
+        <Text size={0} weight="bold">
+          disc
+        </Text>
         <List marker="disc" items={items} />
       </Stack>
       <Stack gap={2}>
-        <Text size={0} weight="bold">decimal</Text>
+        <Text size={0} weight="bold">
+          decimal
+        </Text>
         <List marker="decimal" items={items} />
       </Stack>
       <Stack gap={2}>
-        <Text size={0} weight="bold">square</Text>
+        <Text size={0} weight="bold">
+          square
+        </Text>
         <List marker="square" items={items} />
       </Stack>
     </Group>

--- a/packages/lists/src/list/list.module.css
+++ b/packages/lists/src/list/list.module.css
@@ -1,6 +1,9 @@
 @import "@uiid/tokens/component/list.tokens.css";
 
 .list {
+  margin: 0;
+  padding: 0;
+
   &:where([data-marker="none"]) {
     list-style: none;
   }

--- a/packages/lists/src/list/list.tsx
+++ b/packages/lists/src/list/list.tsx
@@ -3,11 +3,12 @@ import { Stack } from "@uiid/layout";
 import type { ListProps } from "./list.types";
 import { LIST_DEFAULT_MARKER } from "./list.constants";
 import styles from "./list.module.css";
-import { ListItem, ListGroup } from "./subcomponents";
+import { ListItem, ListGroup, ListGroupHeader } from "./subcomponents";
 
 export const List = ({
   marker = LIST_DEFAULT_MARKER,
-  line,
+  category,
+  icon,
   items,
   children,
   ItemProps,
@@ -16,14 +17,11 @@ export const List = ({
 }: ListProps) => {
   const ListElement = marker === "decimal" ? <ol /> : <ul />;
 
-  return (
+  const list = (
     <Stack
       data-slot="list"
       data-marker={marker}
-      data-line={line ? "true" : undefined}
       ax="stretch"
-      p={0}
-      m={0}
       className={styles["list"]}
       render={ListElement}
       {...props}
@@ -31,21 +29,21 @@ export const List = ({
       {items
         ? items.map((item, index) =>
             "items" in item ? (
-              <ListGroup
-                key={item.category ?? index}
-                {...item}
-                {...GroupProps}
-              />
+              <ListGroup key={item.category ?? index} {...item} {...GroupProps} />
             ) : (
-              <ListItem
-                key={index}
-                fullwidth
-                {...item}
-                {...ItemProps}
-              />
+              <ListItem key={index} fullwidth {...item} {...ItemProps} />
             ),
           )
         : children}
+    </Stack>
+  );
+
+  if (!category) return list;
+
+  return (
+    <Stack data-slot="list-section" ax="stretch" fullwidth>
+      <ListGroupHeader category={category} icon={icon} />
+      {list}
     </Stack>
   );
 };

--- a/packages/lists/src/list/list.types.ts
+++ b/packages/lists/src/list/list.types.ts
@@ -19,7 +19,8 @@ export type ListGroupProps = {
 
 export type ListProps = Omit<BoxProps, "direction"> & {
   marker?: ListMarker;
-  line?: boolean;
+  category?: string;
+  icon?: Icon;
   items?: ListItemOrGroup[];
   ItemProps?: Partial<ListItemProps>;
   GroupProps?: Partial<ListGroupProps>;

--- a/packages/lists/src/list/subcomponents/index.ts
+++ b/packages/lists/src/list/subcomponents/index.ts
@@ -1,5 +1,6 @@
 export * from "./list-item";
 export * from "./list-group";
+export * from "./list-group-header";
 export * from "./list-text-block";
 export * from "./list-label";
 export * from "./list-description";

--- a/packages/lists/src/list/subcomponents/list-group-header.tsx
+++ b/packages/lists/src/list/subcomponents/list-group-header.tsx
@@ -1,0 +1,44 @@
+import type { Icon } from "@uiid/icons";
+import { Text } from "@uiid/typography";
+import { Group } from "@uiid/layout";
+
+import { ICON_SIZE_LARGE } from "../list.constants";
+import styles from "../list.module.css";
+
+export type ListGroupHeaderProps = {
+  category?: string;
+  icon?: Icon;
+};
+
+export const ListGroupHeader = ({
+  category,
+  icon: Icon,
+}: ListGroupHeaderProps) => {
+  if (!category) return null;
+
+  return (
+    <Group
+      data-slot="list-group-header"
+      className={styles["list-group-header"]}
+      ay="center"
+      ax="start"
+      gap={2}
+      py={1}
+      fullwidth
+    >
+      {Icon && (
+        <Icon className={styles["list-group-icon"]} size={ICON_SIZE_LARGE} />
+      )}
+      <Text
+        data-slot="list-group-category"
+        render={<h3 />}
+        className={styles["list-group-category"]}
+        weight="bold"
+        size={0}
+      >
+        {category}
+      </Text>
+    </Group>
+  );
+};
+ListGroupHeader.displayName = "ListGroupHeader";

--- a/packages/lists/src/list/subcomponents/list-group.tsx
+++ b/packages/lists/src/list/subcomponents/list-group.tsx
@@ -1,13 +1,12 @@
-import { Text } from "@uiid/typography";
-import { Group, Stack } from "@uiid/layout";
+import { Stack } from "@uiid/layout";
 
 import type { ListGroupProps } from "../list.types";
 
 import { ListItem } from "./list-item";
-import { ICON_SIZE_LARGE } from "../list.constants";
+import { ListGroupHeader } from "./list-group-header";
 import styles from "../list.module.css";
 
-export const ListGroup = ({ category, icon: Icon, items }: ListGroupProps) => {
+export const ListGroup = ({ category, icon, items }: ListGroupProps) => {
   return (
     <Stack
       data-slot="list-group"
@@ -16,41 +15,12 @@ export const ListGroup = ({ category, icon: Icon, items }: ListGroupProps) => {
       fullwidth
       className={styles["list-group"]}
     >
-      {category && (
-        <Group
-          data-slot="list-group-header"
-          className={styles["list-group-header"]}
-          ay="center"
-          ax="start"
-          gap={2}
-          py={1}
-          fullwidth
-        >
-          {Icon && (
-            <Icon
-              className={styles["list-group-icon"]}
-              size={ICON_SIZE_LARGE}
-            />
-          )}
-          <Text
-            data-slot="list-group-category"
-            render={<h3 />}
-            className={styles["list-group-category"]}
-            weight="bold"
-            size={0}
-          >
-            {category}
-          </Text>
-        </Group>
-      )}
+      <ListGroupHeader category={category} icon={icon} />
 
       <ul data-slot="list-group-panel" className={styles["list-group-panel"]}>
         {items.map((item, index) =>
           "items" in item ? (
-            <ListGroup
-              key={item.category ?? index}
-              {...item}
-            />
+            <ListGroup key={item.category ?? index} {...item} />
           ) : (
             <ListItem key={index} {...item} />
           ),

--- a/packages/navigation/src/sidebar/subcomponents/sidebar-list.tsx
+++ b/packages/navigation/src/sidebar/subcomponents/sidebar-list.tsx
@@ -14,7 +14,6 @@ export const SidebarList = ({
     <List
       data-slot="sidebar-list"
       items={items}
-      line
       gap={2}
       fullwidth
       className={cx(styles["sidebar-list"], className)}

--- a/packages/tokens/src/globals.css
+++ b/packages/tokens/src/globals.css
@@ -71,7 +71,6 @@
   }
 
   a {
-    color: var(--theme-primary);
     text-decoration: underline;
     text-underline-offset: 2px;
 


### PR DESCRIPTION
## Summary

- Adds top-level `category` (and `icon`) props to `List` so a group header renders above the whole list — previously `GroupProps={{ category }}` had no effect in the composable/children path.
- Extracts a shared `ListGroupHeader` subcomponent, now reused by both `List` and `ListGroup` (removes duplicated header markup).
- Fixes list indentation: the inline `p={0}` on the list `<ul>` was a `padding` shorthand that overrode the stylesheet's `padding-inline-start` indent rules (both the category `0.5rem` and marker `1rem`). The reset now lives in the `.list` CSS class so those rules cascade by specificity.
- Updates the docs sidebar to use the new `category` shortcut, and shares a `SITEMAP` for the header breadcrumbs.
- Drops the hardcoded `--theme-primary` color from the global anchor style so links inherit surrounding text color.

## Review checklist

- [x] `List` renders a header above items when `category` is set, and renders unchanged when it is not
- [x] List items are indented when a `category` is present (sidebar "Navigation" links)
- [x] `ListGroupHeader` is exported from `@uiid/lists` and used by both `List` and `ListGroup`
- [x] No inline `p={0}`/`m={0}` on the list element; reset lives in `.list` CSS
- [x] Changesets added for `@uiid/lists` and `@uiid/tokens` (patch only)