### PR TITLE
feat(ui): type native HTML attributes on Text and Prose

### DIFF
--- a/.changeset/text-prose-html-attributes.md
+++ b/.changeset/text-prose-html-attributes.md
@@ -1,0 +1,5 @@
+---
+"@uiid/typography": patch
+---
+
+Type native HTML attributes on Text and Prose by intersecting their props with `React.HTMLAttributes` (`HTMLSpanElement` and `HTMLDivElement` respectively), matching Box. Attributes like `id`, `onClick`, `aria-*`, and `title` are now type-valid — they were already forwarded at runtime.

--- a/packages/typography/src/prose/prose.types.ts
+++ b/packages/typography/src/prose/prose.types.ts
@@ -1,9 +1,10 @@
 import type { SpacingProps, RenderProp } from "@uiid/utils";
 
-export type ProseProps = React.PropsWithChildren<{
-  ref?: React.Ref<HTMLDivElement>;
-  render?: RenderProp;
-  style?: React.CSSProperties;
-  className?: string;
-}> &
+export type ProseProps = React.HTMLAttributes<HTMLDivElement> &
+  React.PropsWithChildren<{
+    ref?: React.Ref<HTMLDivElement>;
+    render?: RenderProp;
+    style?: React.CSSProperties;
+    className?: string;
+  }> &
   SpacingProps;

--- a/packages/typography/src/text/text.types.ts
+++ b/packages/typography/src/text/text.types.ts
@@ -4,11 +4,12 @@ import { textVariants } from "./text.variants";
 
 export type TextVariantProps = VariantProps<typeof textVariants>;
 
-export type TextProps = React.PropsWithChildren<{
-  ref?: React.Ref<HTMLSpanElement>;
-  render?: RenderProp;
-  style?: React.CSSProperties;
-  className?: string;
-}> &
+export type TextProps = React.HTMLAttributes<HTMLSpanElement> &
+  React.PropsWithChildren<{
+    ref?: React.Ref<HTMLSpanElement>;
+    render?: RenderProp;
+    style?: React.CSSProperties;
+    className?: string;
+  }> &
   TextVariantProps &
   SpacingProps;


### PR DESCRIPTION
## Summary

- `Text` and `Prose` previously didn't type native HTML attributes (`id`, `onClick`, `aria-*`, `title`, etc.) — passing them was a TS error even though they were already forwarded onto the rendered element at runtime via `...props` → `prepareComponentProps`.
- Only `Box` extended `React.HTMLAttributes`; `Text` and `Prose` did not. This brings all three to parity.
- `TextProps` now intersects `React.HTMLAttributes<HTMLSpanElement>` (renders `<span>`); `ProseProps` intersects `React.HTMLAttributes<HTMLDivElement>` (renders `<div>`).
- Type-only change — no `.tsx` / runtime changes needed.

## Review checklist

- [ ] `TextProps` intersects `React.HTMLAttributes<HTMLSpanElement>` and `ProseProps` intersects `React.HTMLAttributes<HTMLDivElement>`
- [ ] No `.tsx` / runtime changes — diff is types + changeset only
- [ ] `@uiid/typography` builds clean (`tsc -b` + dts), confirming no collision with variant props (`color`, `weight`, etc.)
- [ ] Changeset added for `@uiid/typography` (patch)
