### PR TITLE
refactor(ui): group Card description with icon and title in a stacked lockup

### DIFF
--- a/.changeset/card-header-lockup.md
+++ b/.changeset/card-header-lockup.md
@@ -1,0 +1,5 @@
+---
+"@uiid/cards": patch
+---
+
+Group the Card description with the icon and title in a stacked lockup, laid out beside the action in a two-column header. A taller action slot no longer pushes the description away from the heading.

--- a/packages/cards/src/card/card.module.css
+++ b/packages/cards/src/card/card.module.css
@@ -48,8 +48,17 @@
   }
 }
 
+.card-lockup {
+  flex: 1;
+  min-width: 0;
+}
+
 .card-header-cell {
   min-height: calc(var(--card-icon-size) * 1.5);
+}
+
+.card-action-cell {
+  flex-shrink: 0;
 }
 
 .card-icon {

--- a/packages/cards/src/card/card.tsx
+++ b/packages/cards/src/card/card.tsx
@@ -1,4 +1,4 @@
-import { ConditionalRender, Stack, type StackProps } from "@uiid/layout";
+import { Group, Stack, type StackProps } from "@uiid/layout";
 import { cx } from "@uiid/utils";
 
 import type { CardProps } from "./card.types";
@@ -43,7 +43,9 @@ export const Card = ({
   const hasTitle = Boolean(Title);
   const hasAction = Boolean(Action);
   const hasDescription = Boolean(Description);
-  const hasHeader = hasIcon || hasTitle || hasAction;
+  const hasHeading = hasIcon || hasTitle;
+  const hasLockup = hasHeading || hasDescription;
+  const hasHeader = hasLockup || hasAction;
 
   return (
     <CardContainer {...props} {...ContainerProps}>
@@ -53,40 +55,41 @@ export const Card = ({
         </CardThumbnail>
       )}
 
-      {(hasHeader || hasDescription) && (
-        <ConditionalRender
-          condition={hasHeader && hasDescription}
-          render={<Stack gap={2} fullwidth />}
-        >
-          {hasHeader && (
-            <CardHeader {...HeaderProps}>
-              {hasIcon && (
-                <Container>
-                  <CardIcon icon={Icon} {...IconProps} />
-                </Container>
+      {hasHeader && (
+        <Group data-slot="card-header-region" ay="start" gap={3} fullwidth>
+          {hasLockup && (
+            <Stack className={styles["card-lockup"]} gap={1}>
+              {hasHeading && (
+                <CardHeader {...HeaderProps}>
+                  {hasIcon && (
+                    <Container>
+                      <CardIcon icon={Icon} {...IconProps} />
+                    </Container>
+                  )}
+                  {hasTitle && (
+                    <Container>
+                      <CardTitle {...TitleProps}>{Title}</CardTitle>
+                    </Container>
+                  )}
+                </CardHeader>
               )}
-              {hasTitle && (
-                <Container>
-                  <CardTitle {...TitleProps}>{Title}</CardTitle>
-                </Container>
+              {hasDescription && (
+                <CardDescription {...DescriptionProps}>
+                  {Description}
+                </CardDescription>
               )}
-              {hasAction && (
-                <Container ml="auto">
-                  <CardAction {...ActionProps}>{Action}</CardAction>
-                </Container>
-              )}
-            </CardHeader>
+            </Stack>
           )}
-          {hasDescription && (
-            <CardDescription {...DescriptionProps}>
-              {Description}
-            </CardDescription>
+          {hasAction && (
+            <Container ml="auto" className={styles["card-action-cell"]}>
+              <CardAction {...ActionProps}>{Action}</CardAction>
+            </Container>
           )}
-        </ConditionalRender>
+        </Group>
       )}
 
       {children && (
-        <Stack data-slot="card-inner-container" my={2} {...InnerContainerProps}>
+        <Stack data-slot="card-inner-container" {...InnerContainerProps}>
           {children}
         </Stack>
       )}


### PR DESCRIPTION
## Summary

- Restructure the Card header into a **two-column layout**: a stacked lockup beside the action slot.
- The lockup is a `Stack` — icon + title on line one (`CardHeader`), description on line two — so the description always sits directly under the title.
- The action moved into its own column (`flex-shrink: 0`, top-aligned). A **taller action slot no longer pushes the description away from the heading**.
- New CSS: `.card-lockup { flex: 1; min-width: 0 }` (fills remaining width, lets the description wrap) and `.card-action-cell { flex-shrink: 0 }`.
- `hasHeader` now means "lockup or action present"; added `hasHeading` / `hasLockup` flags. `ConditionalRender` swapped for `Group`.

No public API or prop changes — purely an internal layout restructure.

## Checklist

- [x] `@uiid/cards` builds cleanly (`pnpm build --filter=@uiid/cards`)
- [x] No prop/type signature changes to `CardProps` or any subcomponent
- [x] Description renders directly beneath the title regardless of action height
- [x] Changeset added (`.changeset/card-header-lockup.md`, patch)
